### PR TITLE
Feature/#086 Jest 환경 설정 파일 추가

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -1,9 +1,9 @@
-import react from 'eslint-plugin-react';
-import reactHooks from 'eslint-plugin-react-hooks';
-import jsxA11y from 'eslint-plugin-jsx-a11y';
-import { fileURLToPath } from 'url';
-import { dirname, resolve } from 'path';
-import rootConfig from '../eslint.config.js';
+import react from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
+import jsxA11y from "eslint-plugin-jsx-a11y";
+import { fileURLToPath } from "url";
+import { dirname, resolve } from "path";
+import rootConfig from "../eslint.config.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,15 +13,15 @@ export default [
   ...rootConfig,
 
   {
-    files: ['src/**/*.{ts,tsx}'],
+    files: ["src/**/*.{ts,tsx}"],
     plugins: {
       react,
-      'react-hooks': reactHooks,
-      'jsx-a11y': jsxA11y,
+      "react-hooks": reactHooks,
+      "jsx-a11y": jsxA11y,
     },
     languageOptions: {
       parserOptions: {
-        project: resolve(__dirname, './tsconfig.json'),
+        project: resolve(__dirname, "./tsconfig.json"),
         ecmaFeatures: {
           jsx: true,
         },
@@ -34,52 +34,52 @@ export default [
     },
     rules: {
       // Airbnb React 규칙
-      'react/boolean-prop-naming': ['error', { rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+' }],
-      'react/function-component-definition': [
-        'warn',
+      "react/boolean-prop-naming": ["error", { rule: "^(is|has)[A-Z]([A-Za-z0-9]?)+" }],
+      "react/function-component-definition": [
+        "warn",
         {
-          namedComponents: 'arrow-function',
-          unnamedComponents: 'arrow-function',
+          namedComponents: "arrow-function",
+          unnamedComponents: "arrow-function",
         },
       ],
-      'react/jsx-boolean-value': ['error', 'never'],
-      'react/jsx-closing-bracket-location': ['error', 'line-aligned'],
-      'react/jsx-closing-tag-location': 'error',
-      'react/jsx-curly-spacing': ['error', { when: 'never', children: true }],
-      'react/jsx-equals-spacing': ['error', 'never'],
-      'react/jsx-first-prop-new-line': ['error', 'multiline'],
-      'react/jsx-handler-names': 'warn',
-      'react/jsx-indent': ['error', 2],
-      'react/jsx-key': 'error',
-      'react/jsx-max-props-per-line': ['error', { maximum: 1, when: 'multiline' }],
-      'react/jsx-no-bind': 'warn',
-      'react/jsx-no-duplicate-props': 'error',
-      'react/jsx-pascal-case': 'error',
+      "react/jsx-boolean-value": ["error", "never"],
+      "react/jsx-closing-bracket-location": ["error", "line-aligned"],
+      "react/jsx-closing-tag-location": "error",
+      "react/jsx-curly-spacing": ["error", { when: "never", children: true }],
+      "react/jsx-equals-spacing": ["error", "never"],
+      "react/jsx-first-prop-new-line": ["error", "multiline"],
+      "react/jsx-handler-names": "warn",
+      "react/jsx-indent": ["error", 2],
+      "react/jsx-key": "error",
+      "react/jsx-max-props-per-line": ["error", { maximum: 1, when: "multiline" }],
+      "react/jsx-no-bind": "warn",
+      "react/jsx-no-duplicate-props": "error",
+      "react/jsx-pascal-case": "error",
 
       // 개발 초기를 위한 규칙 완화
-      'react/react-in-jsx-scope': 'off',
-      'react/jsx-props-no-spreading': 'off',
-      'react/require-default-props': 'off',
-      'react/prop-types': 'off',
+      "react/react-in-jsx-scope": "off",
+      "react/jsx-props-no-spreading": "off",
+      "react/require-default-props": "off",
+      "react/prop-types": "off",
 
       // React Hooks
-      'react-hooks/rules-of-hooks': 'error',
-      'react-hooks/exhaustive-deps': 'warn',
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "warn",
 
       // JSX A11y - 개발 초기에는 경고로만
-      'jsx-a11y/click-events-have-key-events': 'warn',
-      'jsx-a11y/no-static-element-interactions': 'warn',
-      'jsx-a11y/label-has-associated-control': 'warn',
+      "jsx-a11y/click-events-have-key-events": "warn",
+      "jsx-a11y/no-static-element-interactions": "warn",
+      "jsx-a11y/label-has-associated-control": "warn",
     },
     settings: {
-      'import/resolver': {
+      "import/resolver": {
         typescript: {
           alwaysTryTypes: true,
-          project: resolve(__dirname, './tsconfig.json'),
+          project: resolve(__dirname, "./tsconfig.json"),
         },
       },
       react: {
-        version: 'detect',
+        version: "detect",
       },
     },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -84,13 +84,13 @@ const config = [
   },
   {
     ignores: [
-      "node_modules/",
+      "**/node_modules/",
       "**/dist/",
-      "build/",
-      "coverage/",
-      "*.config.js",
-      "src/**/*.test.js",
-      "public/*",
+      "**/build/",
+      "**/coverage/",
+      "**/*.config.js",
+      "**/src/**/*.test.js",
+      "**/public/*",
     ],
   },
   // 설정 파일에 대한 특별 규칙

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,36 +1,36 @@
-import js from '@eslint/js';
-import tseslint from '@typescript-eslint/eslint-plugin';
-import tsparser from '@typescript-eslint/parser';
-import prettierPlugin from 'eslint-plugin-prettier';
-import importPlugin from 'eslint-plugin-import';
+import js from "@eslint/js";
+import tseslint from "@typescript-eslint/eslint-plugin";
+import tsparser from "@typescript-eslint/parser";
+import prettierPlugin from "eslint-plugin-prettier";
+import importPlugin from "eslint-plugin-import";
 
 const airbnbRules = {
   // Airbnb 스타일 가이드의 핵심 규칙들
-  'no-var': 'error',
-  'prefer-const': 'error',
-  'prefer-template': 'error',
-  'no-param-reassign': 'error',
-  'object-shorthand': 'error',
-  'prefer-destructuring': ['error', { array: true, object: true }],
-  'no-array-constructor': 'error',
-  'func-style': ['error', 'expression'],
-  'arrow-parens': ['error', 'always'],
-  'arrow-body-style': ['warn', 'as-needed'],
-  'no-duplicate-imports': 'error',
-  'one-var': ['error', 'never'],
-  'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],
-  'spaced-comment': ['error', 'always'],
-  'no-underscore-dangle': 'off',
-  'max-len': ['warn', { code: 100, ignoreComments: true }],
+  "no-var": "error",
+  "prefer-const": "error",
+  "prefer-template": "error",
+  "no-param-reassign": "error",
+  "object-shorthand": "error",
+  "prefer-destructuring": ["error", { array: true, object: true }],
+  "no-array-constructor": "error",
+  "func-style": ["error", "expression"],
+  "arrow-parens": ["error", "always"],
+  "arrow-body-style": ["warn", "as-needed"],
+  "no-duplicate-imports": "error",
+  "one-var": ["error", "never"],
+  "no-plusplus": ["error", { allowForLoopAfterthoughts: true }],
+  "spaced-comment": ["error", "always"],
+  "no-underscore-dangle": "off",
+  "max-len": ["warn", { code: 100, ignoreComments: true }],
 
   // Import 규칙
-  'import/prefer-default-export': 'off',
-  'import/no-default-export': 'off',
-  'import/extensions': 'off',
-  'import/no-extraneous-dependencies': 'off',
-  'import/first': 'error',
-  'import/newline-after-import': 'error',
-  'import/no-duplicates': 'error',
+  "import/prefer-default-export": "off",
+  "import/no-default-export": "off",
+  "import/extensions": "off",
+  "import/no-extraneous-dependencies": "off",
+  "import/first": "error",
+  "import/newline-after-import": "error",
+  "import/no-duplicates": "error",
 };
 
 /** @type {import('eslint').Linter.FlatConfig[]} */
@@ -38,16 +38,16 @@ const config = [
   js.configs.recommended,
   // 공통 설정
   {
-    files: ['**/*.{ts,tsx,js,jsx}'],
+    files: ["**/*.{ts,tsx,js,jsx}"],
     plugins: {
-      '@typescript-eslint': tseslint,
+      "@typescript-eslint": tseslint,
       prettier: prettierPlugin,
       import: importPlugin,
     },
     languageOptions: {
       parser: tsparser,
       ecmaVersion: 2022,
-      sourceType: 'module',
+      sourceType: "module",
       parserOptions: {
         ecmaFeatures: {
           jsx: true,
@@ -60,46 +60,45 @@ const config = [
 
       // TypeScript
       ...tseslint.configs.recommended.rules,
-      '@typescript-eslint/no-unused-vars': [
-        'warn',
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
         {
           varsIgnorePattern:
-            '^(js|Injectable|Controller|Get|Post|Put|Delete|Patch|Options|Head|All)$',
-          argsIgnorePattern: '^_',
+            "^(js|Injectable|Controller|Get|Post|Put|Delete|Patch|Options|Head|All)$",
+          argsIgnorePattern: "^_",
           ignoreRestSiblings: true,
         },
       ],
-      '@typescript-eslint/explicit-function-return-type': 'off',
-      '@typescript-eslint/explicit-module-boundary-types': 'off',
-      '@typescript-eslint/no-explicit-any': 'warn',
+      "@typescript-eslint/explicit-function-return-type": "off",
+      "@typescript-eslint/explicit-module-boundary-types": "off",
+      "@typescript-eslint/no-explicit-any": "warn",
 
       // Prettier
       ...prettierPlugin.configs.recommended.rules,
 
       // 개발 초기 단계를 위한 규칙 완화
-      'no-console': 'off',
-      'no-unused-vars': 'off', // TypeScript rule을 대신 사용
-      'no-undef': 'off', // TypeScript에서 처리
+      "no-console": "off",
+      "no-unused-vars": "off", // TypeScript rule을 대신 사용
+      "no-undef": "off", // TypeScript에서 처리
     },
   },
   {
     ignores: [
-      'node_modules/',
-      'dist/',
-      'build/',
-      'coverage/',
-      '*.config.js',
-      'src/**/*.test.js',
-      'public/*',
-      'server/dist/'
+      "node_modules/",
+      "**/dist/",
+      "build/",
+      "coverage/",
+      "*.config.js",
+      "src/**/*.test.js",
+      "public/*",
     ],
   },
   // 설정 파일에 대한 특별 규칙
   {
-    files: ['**/eslint.config.js', '**/prettier.config.js', '**/vite.config.ts'],
+    files: ["**/eslint.config.js", "**/prettier.config.js", "**/vite.config.ts"],
     rules: {
-      '@typescript-eslint/no-unused-vars': 'off',
-      'import/no-unused-modules': 'off',
+      "@typescript-eslint/no-unused-vars": "off",
+      "import/no-unused-modules": "off",
     },
   },
 ];

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "pnpm --filter server test",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "lint": "eslint . --fix",
     "lint:client": "eslint \"client/src/**/*.{ts,tsx}\" --fix",

--- a/server/eslint.config.js
+++ b/server/eslint.config.js
@@ -1,6 +1,6 @@
-import { fileURLToPath } from 'url';
-import { dirname, resolve } from 'path';
-import rootConfig from '../eslint.config.js';
+import { fileURLToPath } from "url";
+import { dirname, resolve } from "path";
+import rootConfig from "../eslint.config.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -10,10 +10,10 @@ export default [
   ...rootConfig,
 
   {
-    files: ['src/**/*.ts', 'test/**/*.ts'],
+    files: ["src/**/*.ts", "test/**/*.ts"],
     languageOptions: {
       parserOptions: {
-        project: resolve(__dirname, './tsconfig.json'),
+        project: resolve(__dirname, "./tsconfig.json"),
       },
       globals: {
         // Test globals
@@ -34,11 +34,11 @@ export default [
       },
     },
     rules: {
-      'no-console': ['warn', { allow: ['warn', 'error', 'info'] }],
-      '@typescript-eslint/interface-name-prefix': 'off',
-      '@typescript-eslint/explicit-function-return-type': 'off',
-      '@typescript-eslint/explicit-module-boundary-types': 'off',
-      '@typescript-eslint/no-explicit-any': 'warn',
+      "no-console": ["warn", { allow: ["warn", "error", "info"] }],
+      "@typescript-eslint/interface-name-prefix": "off",
+      "@typescript-eslint/explicit-function-return-type": "off",
+      "@typescript-eslint/explicit-module-boundary-types": "off",
+      "@typescript-eslint/no-explicit-any": "warn",
     },
   },
 ];

--- a/server/jest.config.ts
+++ b/server/jest.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from "jest";
+
+const config: Config = {
+  moduleFileExtensions: ["js", "json", "ts"],
+  rootDir: ".",
+  testRegex: ".*\\.spec\\.ts$",
+  transform: {
+    "^.+\\.(t|j)s$": "ts-jest",
+  },
+  collectCoverageFrom: ["**/*.(t|j)s"],
+  coverageDirectory: "./coverage",
+  testEnvironment: "node",
+};
+
+export default config;

--- a/server/src/app.controller.spec.ts
+++ b/server/src/app.controller.spec.ts
@@ -1,8 +1,8 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { AppController } from './app.controller';
-import { AppService } from './app.service';
+import { Test, TestingModule } from "@nestjs/testing";
+import { AppController } from "./app.controller";
+import { AppService } from "./app.service";
 
-describe('AppController', () => {
+describe("AppController", () => {
   let appController: AppController;
 
   beforeEach(async () => {
@@ -14,9 +14,9 @@ describe('AppController', () => {
     appController = app.get<AppController>(AppController);
   });
 
-  describe('root', () => {
+  describe("root", () => {
     it('should return "Hello World!"', () => {
-      expect(appController.getHello()).toBe('Hello World!');
+      expect(appController.getHello()).toBe("Hello World!");
     });
   });
 });

--- a/server/src/app.controller.ts
+++ b/server/src/app.controller.ts
@@ -1,6 +1,6 @@
 // server/src/app.controller.ts
-import { Controller, Get, Injectable } from '@nestjs/common';
-import { AppService } from './app.service';
+import { Controller, Get, Injectable } from "@nestjs/common";
+import { AppService } from "./app.service";
 
 @Controller()
 export class AppController {

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -1,6 +1,6 @@
-import { Module } from '@nestjs/common';
-import { AppController } from './app.controller';
-import { AppService } from './app.service';
+import { Module } from "@nestjs/common";
+import { AppController } from "./app.controller";
+import { AppService } from "./app.service";
 
 @Module({
   imports: [],

--- a/server/src/app.service.ts
+++ b/server/src/app.service.ts
@@ -1,8 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable } from "@nestjs/common";
 
 @Injectable()
 export class AppService {
   getHello(): string {
-    return 'Hello World!';
+    return "Hello World!";
   }
 }

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,5 +1,5 @@
-import { NestFactory } from '@nestjs/core';
-import { AppModule } from './app.module';
+import { NestFactory } from "@nestjs/core";
+import { AppModule } from "./app.module";
 
 const bootstrap = async () => {
   const app = await NestFactory.create(AppModule);

--- a/server/test/app.e2e-spec.ts
+++ b/server/test/app.e2e-spec.ts
@@ -1,9 +1,9 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
-import * as request from 'supertest';
-import { AppModule } from './../src/app.module';
+import { Test, TestingModule } from "@nestjs/testing";
+import { INestApplication } from "@nestjs/common";
+import request from "supertest";
+import { AppModule } from "./../src/app.module";
 
-describe('AppController (e2e)', () => {
+describe("AppController (e2e)", () => {
   let app: INestApplication;
 
   beforeEach(async () => {
@@ -15,7 +15,7 @@ describe('AppController (e2e)', () => {
     await app.init();
   });
 
-  it('/ (GET)', () => {
-    return request(app.getHttpServer()).get('/').expect(200).expect('Hello World!');
+  it("/ (GET)", () => {
+    return request(app.getHttpServer()).get("/").expect(200).expect("Hello World!");
   });
 });


### PR DESCRIPTION
## 📝 변경 사항

- #086
- Jest 환경 설정 파일 추가

## 🔍 변경 사항 설명

- 이전까지 NestJS에서 테스트를 수행했을 때 다음 문제가 발생해서 환경 설정 파일을 추가했습니다.
    - TypeScript 문법 지원 안됨
    - ECMAScript 모듈 지원 안됨
- [참고 링크](https://abrupt-feta-9a9.notion.site/NestJS-Jest-ec242227d56b47aea0dba07a81c48aab)

## 🙏 질문 사항

- [ ] 리뷰어에게 부탁하고싶은 체크리스트를 추가합니다.

## 📷 스크린샷 (선택)

- UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

## ✅ 작성자 체크리스트

- [x] Self-review: 코드가 스스로 검토됨
- [x] Unit tests 추가 또는 수정
- [x] 로컬에서 모든 기능이 정상 작동함
- [x] 린터 및 포맷터로 코드 정리됨
- [x] 의존성 업데이트 확인
- [ ] 문서 업데이트 또는 주석 추가 (필요 시)
