### PR TITLE
Feature/#085 auto_merge_approved_pr.yml 오류 수정

### DIFF
--- a/.github/workflows/auto_merge_approved_pr.yml
+++ b/.github/workflows/auto_merge_approved_pr.yml
@@ -20,14 +20,14 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number,
             });
-            return JSON.stringify(pr);
+            core.setOutput('result', JSON.stringify(pr));
       - name: "Check Approvals"
         id: check
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const pr = JSON.parse(steps.pr.outputs.result);
+            const pr = JSON.parse(`${{ steps.pr.outputs.result }}`);
             const reviews = await github.rest.pulls.listReviews({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -36,7 +36,7 @@ jobs:
             const approvals = reviews.data.filter(review => review.state === 'APPROVED');
             core.setOutput('result', approvals.length >= 2);
       - name: "Merge PR"
-        if: steps.check.outputs.result
+        if: ${{ steps.check.outputs.result == 'true' }}
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto_merge_approved_pr.yml
+++ b/.github/workflows/auto_merge_approved_pr.yml
@@ -24,10 +24,12 @@ jobs:
       - name: "Check Approvals"
         id: check
         uses: actions/github-script@v6
+        env:
+          PR_RESULT: ${{ steps.pr.outputs.result }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const pr = JSON.parse(`${{ steps.pr.outputs.result }}`);
+            const pr = JSON.parse(process.env.PR_RESULT);
             const reviews = await github.rest.pulls.listReviews({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/auto_merge_approved_pr.yml
+++ b/.github/workflows/auto_merge_approved_pr.yml
@@ -8,43 +8,30 @@ jobs:
   auto_merge:
     runs-on: ubuntu-latest
     steps:
-      - name: "Get Pull Request"
-        id: pr
+      - name: "Check Approvals"
+        id: check
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           result-encoding: string
           script: |
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-            });
-            core.setOutput('result', JSON.stringify(pr));
-      - name: "Check Approvals"
-        id: check
-        uses: actions/github-script@v6
-        env:
-          PR_RESULT: ${{ steps.pr.outputs.result }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const pr = JSON.parse(process.env.PR_RESULT);
+            const pull_number = context.payload.pull_request.number;
             const reviews = await github.rest.pulls.listReviews({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: pr.number,
+              pull_number: pull_number,
             });
             const approvals = reviews.data.filter(review => review.state === 'APPROVED');
-            core.setOutput('result', approvals.length >= 2);
+            return approvals.length >= 2;
       - name: "Merge PR"
         if: ${{ steps.check.outputs.result == 'true' }}
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const pull_number = context.payload.pull_request.number;
             await github.rest.pulls.merge({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
+              pull_number: pull_number,
             });


### PR DESCRIPTION
## 📝 변경 사항

- #085
- auto_merge_approved_pr.yml에서 발생하는 오류 수정

## 🔍 변경 사항 설명

```
Run actions/github-script@v6
ReferenceError: steps is not defined
    at eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v6/dist/index.js:15143:16), <anonymous>:3:23)
    at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v6/dist/index.js:15144:12)
    at main (/home/runner/work/_actions/actions/github-script/v6/dist/index.js:15236:26)
    at /home/runner/work/_actions/actions/github-script/v6/dist/index.js:15217:1
    at /home/runner/work/_actions/actions/github-script/v6/dist/index.js:15268:3
    at Object.<anonymous> (/home/runner/work/_actions/actions/github-script/v6/dist/index.js:15271:12)
    at Module._compile (node:internal/modules/cjs/loader:1358:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1416:10)
    at Module.load (node:internal/modules/cjs/loader:1208:32)
    at Module._load (node:internal/modules/cjs/loader:1024:12)
Error: Unhandled error: ReferenceError: steps is not defined
```

### 1차 수정

- `return`을 `core.setOutput`으로 통일
- 스크립트에 변수가 제대로 들어갈 수 있도록 수정 `${{ steps.pr.outputs.result }}`

### 2차 수정

- `actions/github-script`에서 `result`가 이미 예약된 변수명임(스크립트의 return값)
- 따라서 `core.setOutput`로 작성했던 스크립트를 다시 `return`으로 수정함
- Get Pull Request와 Check Approvals로 분리된 step을 하나로 통합함

## 🙏 질문 사항

- [ ] 리뷰어에게 부탁하고싶은 체크리스트를 추가합니다.

## 📷 스크린샷 (선택)

- UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

## ✅ 작성자 체크리스트

- [ ] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [ ] 로컬에서 모든 기능이 정상 작동함
- [ ] 린터 및 포맷터로 코드 정리됨
- [ ] 의존성 업데이트 확인
- [ ] 문서 업데이트 또는 주석 추가 (필요 시)
