### PR TITLE
Feature/#085 auto_merge_approved_pr.yml 오류 수정

### DIFF
--- a/.github/workflows/auto_merge_approved_pr.yml
+++ b/.github/workflows/auto_merge_approved_pr.yml
@@ -22,7 +22,9 @@ jobs:
               pull_number: pull_number,
             });
             const approvals = reviews.data.filter(review => review.state === 'APPROVED');
-            return approvals.length >= 2;
+            const approvalCount = approvals.length;
+            core.info(`PR #${pull_number} has ${approvalCount} approval(s).`);
+            return approvalCount >= 2;
       - name: "Merge PR"
         if: ${{ steps.check.outputs.result == 'true' }}
         uses: actions/github-script@v6
@@ -30,8 +32,46 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const pull_number = context.payload.pull_request.number;
-            await github.rest.pulls.merge({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pull_number,
-            });
+
+            // PR 정보 및 병합 가능 상태 확인
+            let pr;
+            for (let i = 0; i < 5; i++) { // 최대 5회 재시도
+              const { data } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pull_number,
+              });
+              pr = data;
+
+              if (pr.state !== 'open') {
+                core.info(`PR #${pull_number} is not open (state: ${pr.state}).`);
+                return;
+              }
+
+              if (pr.mergeable === true) {
+                break; // 병합 가능하면 루프 종료
+              } else if (pr.mergeable === false) {
+                core.info(`PR #${pull_number} cannot be merged due to conflicts or other issues.`);
+                return;
+              } else {
+                // mergeable이 null인 경우 (계산 중), 잠시 대기 후 재시도
+                await new Promise(resolve => setTimeout(resolve, 2000)); // 2초 대기
+              }
+            }
+
+            if (pr.mergeable !== true) {
+              core.info(`PR #${pull_number} mergeable status is unknown after retries.`);
+              return;
+            }
+
+            // PR 병합 시도
+            try {
+              await github.rest.pulls.merge({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pull_number,
+              });
+              core.info(`PR #${pull_number} has been merged successfully.`);
+            } catch (error) {
+              core.info(`Failed to merge PR #${pull_number}: ${error.message}`);
+            }


### PR DESCRIPTION
## 📝 변경 사항

- #085
- PR을 자동으로 merge할 수 없을 때 에러 대신 상태 메시지가 나오도록 수정

## 🔍 변경 사항 설명

- 다음 경우에 대해 에러 대신 상태 메시지가 나오도록 했습니다.
    - approve 수가 부족할 때
    - PR이 이미 닫혀있을 때
    - 병합 충돌이 있을 때

## 🙏 질문 사항

- [ ] 리뷰어에게 부탁하고싶은 체크리스트를 추가합니다.

## 📷 스크린샷 (선택)

- UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

## ✅ 작성자 체크리스트

- [ ] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [ ] 로컬에서 모든 기능이 정상 작동함
- [ ] 린터 및 포맷터로 코드 정리됨
- [ ] 의존성 업데이트 확인
- [ ] 문서 업데이트 또는 주석 추가 (필요 시)
