### PR TITLE
Feature/#104 탭 브라우징 반응형 구현

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,8 @@
     "framer-motion": "^11.11.11",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "socket.io-client": "^4.8.1"
+    "socket.io-client": "^4.8.1",
+    "zustand": "^5.0.1"
   },
   "devDependencies": {
     "@pandabox/prettier-plugin": "^0.1.3",

--- a/client/src/components/sidebar/Sidebar.animation.ts
+++ b/client/src/components/sidebar/Sidebar.animation.ts
@@ -1,3 +1,5 @@
+import { SIDE_BAR } from "@constants/size";
+
 export const animation = {
   initial: {
     x: -100,
@@ -12,5 +14,32 @@ export const animation = {
     stiffness: 300,
     damping: 30,
     duration: 0.5,
+  },
+};
+
+export const sidebarVariants = {
+  open: {
+    width: `${SIDE_BAR.WIDTH}px`,
+    transition: { duration: 0.2, ease: "easeOut" },
+  },
+  closed: {
+    width: `${SIDE_BAR.MIN_WIDTH}px`,
+  },
+};
+
+export const contentVariants = {
+  open: {
+    opacity: 1,
+    x: 0,
+    display: "flex",
+    transition: { delay: 0.2 },
+  },
+  closed: {
+    opacity: 0,
+    x: -20,
+    transitionEnd: {
+      delay: 0.2,
+      display: "none",
+    },
   },
 };

--- a/client/src/components/sidebar/Sidebar.style.ts
+++ b/client/src/components/sidebar/Sidebar.style.ts
@@ -7,7 +7,6 @@ export const sidebarContainer = cx(
     display: "flex",
     gap: "lg",
     flexDirection: "column",
-    width: "sidebar.width",
     height: "calc(100vh - 40px)",
     marginBlock: "20px",
   }),
@@ -23,4 +22,14 @@ export const plusIconBox = css({
   display: "flex",
   justifyContent: "start",
   paddingInline: "md",
+});
+
+export const sidebarToggleButton = css({
+  zIndex: 10,
+  position: "absolute",
+  top: "4px",
+  right: "16px",
+  color: "gray.500",
+  fontSize: "24px",
+  cursor: "pointer",
 });

--- a/client/src/components/sidebar/Sidebar.tsx
+++ b/client/src/components/sidebar/Sidebar.tsx
@@ -1,10 +1,11 @@
-import { motion, AnimatePresence } from "framer-motion";
+import { motion } from "framer-motion";
 import { IconButton } from "@components/button/IconButton";
+import { useIsSidebarOpen, useSidebarActions } from "src/stores/useSidebarStore";
 import { Page } from "src/types/page";
 import { MenuButton } from "./MenuButton";
 import { PageItem } from "./PageItem";
-import { animation } from "./Sidebar.animation";
-import { sidebarContainer, navWrapper, plusIconBox } from "./Sidebar.style";
+import { animation, contentVariants, sidebarVariants } from "./Sidebar.animation";
+import { sidebarContainer, navWrapper, plusIconBox, sidebarToggleButton } from "./Sidebar.style";
 
 export const Sidebar = ({
   pages,
@@ -15,26 +16,36 @@ export const Sidebar = ({
   handlePageAdd: () => void;
   handlePageSelect: (pageId: number, isSidebar: boolean) => void;
 }) => {
+  const isSidebarOpen = useIsSidebarOpen();
+  const { toggleSidebar } = useSidebarActions();
+
   return (
-    <aside className={sidebarContainer}>
-      <MenuButton />
-      <AnimatePresence>
-        <nav className={navWrapper}>
-          {pages?.map((item) => (
-            <motion.div
-              key={item.id}
-              initial={animation.initial}
-              animate={animation.animate}
-              transition={animation.transition}
-            >
-              <PageItem {...item} onClick={() => handlePageSelect(item.id, true)} />
-            </motion.div>
-          ))}
-        </nav>
-      </AnimatePresence>
-      <motion.div className={plusIconBox}>
-        <IconButton icon="➕" size="sm" onClick={handlePageAdd} />
-      </motion.div>
-    </aside>
+    <motion.aside
+      className={sidebarContainer}
+      initial="open"
+      animate={isSidebarOpen ? "open" : "closed"}
+      variants={sidebarVariants}
+    >
+      <div className={sidebarToggleButton} onClick={toggleSidebar}>
+        {isSidebarOpen ? "«" : "»"}
+      </div>
+
+      <motion.nav className={navWrapper} variants={contentVariants}>
+        <MenuButton />
+        {pages?.map((item) => (
+          <motion.div
+            key={item.id}
+            initial={animation.initial}
+            animate={animation.animate}
+            transition={animation.transition}
+          >
+            <PageItem {...item} onClick={() => handlePageSelect(item.id, true)} />
+          </motion.div>
+        ))}
+        <div className={plusIconBox}>
+          <IconButton icon="➕" size="sm" onClick={handlePageAdd} />
+        </div>
+      </motion.nav>
+    </motion.aside>
   );
 };

--- a/client/src/constants/size.ts
+++ b/client/src/constants/size.ts
@@ -7,5 +7,6 @@ export const PAGE = {
 };
 
 export const SIDE_BAR = {
+  MIN_WIDTH: 40,
   WIDTH: 300,
 };

--- a/client/src/stores/useSidebarStore.ts
+++ b/client/src/stores/useSidebarStore.ts
@@ -1,0 +1,18 @@
+import { create } from "zustand";
+
+interface SidebarStore {
+  isSidebarOpen: boolean;
+  actions: {
+    toggleSidebar: () => void;
+  };
+}
+
+const useSidebarStore = create<SidebarStore>((set) => ({
+  isSidebarOpen: true,
+  actions: {
+    toggleSidebar: () => set((state) => ({ isSidebarOpen: !state.isSidebarOpen })),
+  },
+}));
+
+export const useIsSidebarOpen = () => useSidebarStore((state) => state.isSidebarOpen);
+export const useSidebarActions = () => useSidebarStore((state) => state.actions);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       socket.io-client:
         specifier: ^4.8.1
         version: 4.8.1
+      zustand:
+        specifier: ^5.0.1
+        version: 5.0.1(@types/react@18.3.12)(react@18.3.1)
     devDependencies:
       '@pandabox/prettier-plugin':
         specifier: ^0.1.3
@@ -4571,6 +4574,24 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zustand@5.0.1:
+    resolution: {integrity: sha512-pRET7Lao2z+n5R/HduXMio35TncTlSW68WsYBq2Lg1ASspsNGjpwLAsij3RpouyV6+kHMwwwzP0bZPD70/Jx/w==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -9747,3 +9768,8 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zustand@5.0.1(@types/react@18.3.12)(react@18.3.1):
+    optionalDependencies:
+      '@types/react': 18.3.12
+      react: 18.3.1


### PR DESCRIPTION
## 📝 변경 사항

- 사이드바 반응형 구현

## 🔍 변경 사항 설명

- constants의 상수만 바꾸면 사이드바 크기 수정가능합니다.
- sidebar 열림/닫힘의 경우, zustand로 관리하는편이 좋다 생각했습니다 (여러곳에서 접근해야함)
- zustand 설치 및 적용
  - 현훈님이 정리하신 부분이랑 해당 [블로그](https://tkdodo.eu/blog/working-with-zustand) 참고해서 구현했습니다.
  - 자세한 거는 따로 위키에 작성하겠습니다!

## 🙏 질문 사항

- [ ] [선행 리뷰](https://github.com/boostcampwm-2024/web33-Nocta/pull/101) 부탁드립니다!
- [ ] 변경사항은 [해당 커밋](https://github.com/boostcampwm-2024/web33-Nocta/pull/105/commits/94607b2c5719a455b3fa25bd2fc15f264f43cd51)부터 봐주시면 됩니당!
 
## 📷 스크린샷 (선택)

https://github.com/user-attachments/assets/ef3efea7-1eb5-4d6a-a5f3-0d8ac367455f

## ✅ 작성자 체크리스트

- [ ] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [ ] 로컬에서 모든 기능이 정상 작동함
- [ ] 린터 및 포맷터로 코드 정리됨
- [ ] 의존성 업데이트 확인
- [ ] 문서 업데이트 또는 주석 추가 (필요 시)
