### PR TITLE
fix: socket URL api로 잘못 올라간 것 수정

### DIFF
--- a/client/src/stores/useSocketStore.ts
+++ b/client/src/stores/useSocketStore.ts
@@ -57,7 +57,7 @@ export const useSocketStore = create<SocketStore>((set, get) => ({
     }
 
     const SERVER_URL =
-      process.env.NODE_ENV === "development" ? "http://localhost:3000" : "https://api.nocta.site";
+      process.env.NODE_ENV === "development" ? "http://localhost:3000" : "https://nocta.site";
 
     const socket = io(SERVER_URL, {
       path: "/api/socket.io",


### PR DESCRIPTION
#166

## 📝 변경 사항

- client의 socket.io에 사용되는 URL이 https://api.nocta.site로 올라가 있던점 수정

## 🔍 변경 사항 설명

- api.nocta.site -> nocta.site 로 수정
## 🙏 질문 사항

- [ ] 리뷰어에게 부탁하고싶은 체크리스트를 추가합니다.

## 📷 스크린샷 (선택)

- UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

## ✅ 작성자 체크리스트

- [x] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [x] 로컬에서 모든 기능이 정상 작동함
- [ ] 린터 및 포맷터로 코드 정리됨
- [x] 의존성 업데이트 확인
- [ ] 문서 업데이트 또는 주석 추가 (필요 시)
