### PR TITLE
Feature/#168 블록 드래그앤드랍 서버 반영

### DIFF
--- a/@noctaCrdt/Interfaces.ts
+++ b/@noctaCrdt/Interfaces.ts
@@ -93,10 +93,11 @@ export interface WorkSpaceSerializedProps {
   pageList: Page[];
   authUser: Map<string, string>;
 }
-export interface RemoteReorderOperation {
+export interface RemoteBlockReorderOperation {
   targetId: BlockId;
   beforeId: BlockId | null;
   afterId: BlockId | null;
   clock: number;
   client: number;
+  pageId: string;
 }

--- a/client/src/features/editor/Editor.tsx
+++ b/client/src/features/editor/Editor.tsx
@@ -28,16 +28,6 @@ export interface EditorStateProps {
 }
 // TODO: pageId, editorCRDT를 props로 받아와야함
 export const Editor = ({ onTitleChange, pageId, serializedEditorData }: EditorProps) => {
-  /*
-  const {
-    sendCharInsertOperation,
-    sendCharDeleteOperation,
-    subscribeToRemoteOperations,
-    sendBlockInsertOperation,
-    sendBlockDeleteOperation,
-    sendBlockUpdateOperation,
-  } = useSocket();
-  */
   const {
     sendCharInsertOperation,
     sendCharDeleteOperation,
@@ -62,6 +52,7 @@ export const Editor = ({ onTitleChange, pageId, serializedEditorData }: EditorPr
     editorCRDT: editorCRDT.current,
     editorState,
     setEditorState,
+    pageId,
   });
 
   const { handleKeyDown } = useMarkdownGrammer({
@@ -222,6 +213,18 @@ export const Editor = ({ onTitleChange, pageId, serializedEditorData }: EditorPr
           currentBlock: prev.currentBlock,
         }));
       },
+
+      onRemoteBlockReorder: (operation) => {
+        console.log(operation, "block : 재정렬 확인합니다이");
+        if (!editorCRDT.current) return;
+        editorCRDT.current.remoteReorder(operation);
+        setEditorState((prev) => ({
+          clock: editorCRDT.current.clock,
+          linkedList: editorCRDT.current.LinkedList,
+          currentBlock: prev.currentBlock,
+        }));
+      },
+
       onRemoteCursor: (position) => {
         console.log(position, "커서위치 수신");
       },

--- a/client/src/features/editor/hooks/useBlockDragAndDrop.ts
+++ b/client/src/features/editor/hooks/useBlockDragAndDrop.ts
@@ -1,18 +1,21 @@
 // hooks/useBlockDragAndDrop.ts
 import { DragEndEvent, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
 import { EditorCRDT } from "@noctaCrdt/Crdt";
+import { useSocketStore } from "@src/stores/useSocketStore.ts";
 import { EditorStateProps } from "../Editor";
 
 interface UseBlockDragAndDropProps {
   editorCRDT: EditorCRDT;
   editorState: EditorStateProps;
   setEditorState: React.Dispatch<React.SetStateAction<EditorStateProps>>;
+  pageId: string;
 }
 
 export const useBlockDragAndDrop = ({
   editorCRDT,
   editorState,
   setEditorState,
+  pageId,
 }: UseBlockDragAndDropProps) => {
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -21,6 +24,8 @@ export const useBlockDragAndDrop = ({
       },
     }),
   );
+
+  const { sendBlockReorderOperation } = useSocketStore();
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
@@ -73,11 +78,14 @@ export const useBlockDragAndDrop = ({
       }
 
       // EditorCRDT의 현재 상태로 작업
-      editorCRDT.localReorder({
+      const operation = editorCRDT.localReorder({
         targetId: targetNode.id,
         beforeId: beforeNode?.id || null,
         afterId: afterNode?.id || null,
+        pageId,
       });
+
+      sendBlockReorderOperation(operation);
 
       // EditorState 업데이트
       setEditorState({

--- a/client/src/stores/useSocketStore.ts
+++ b/client/src/stores/useSocketStore.ts
@@ -5,6 +5,7 @@ import {
   RemoteCharInsertOperation,
   RemoteCharDeleteOperation,
   RemoteBlockUpdateOperation,
+  RemoteBlockReorderOperation,
   CursorPosition,
   WorkSpaceSerializedProps,
 } from "@noctaCrdt/Interfaces";
@@ -24,6 +25,7 @@ interface SocketStore {
   sendCharInsertOperation: (operation: RemoteCharInsertOperation) => void;
   sendBlockDeleteOperation: (operation: RemoteBlockDeleteOperation) => void;
   sendCharDeleteOperation: (operation: RemoteCharDeleteOperation) => void;
+  sendBlockReorderOperation: (operation: RemoteBlockReorderOperation) => void;
   sendCursorPosition: (position: CursorPosition) => void;
   subscribeToRemoteOperations: (handlers: RemoteOperationHandlers) => (() => void) | undefined;
   subscribeToPageOperations: (handlers: PageOperationsHandlers) => (() => void) | undefined;
@@ -34,6 +36,7 @@ interface RemoteOperationHandlers {
   onRemoteBlockUpdate: (operation: RemoteBlockUpdateOperation) => void;
   onRemoteBlockInsert: (operation: RemoteBlockInsertOperation) => void;
   onRemoteBlockDelete: (operation: RemoteBlockDeleteOperation) => void;
+  onRemoteBlockReorder: (operation: RemoteBlockReorderOperation) => void;
   onRemoteCharInsert: (operation: RemoteCharInsertOperation) => void;
   onRemoteCharDelete: (operation: RemoteCharDeleteOperation) => void;
   onRemoteCursor: (position: CursorPosition) => void;
@@ -146,6 +149,11 @@ export const useSocketStore = create<SocketStore>((set, get) => ({
     socket?.emit("cursor", position);
   },
 
+  sendBlockReorderOperation: (operation: RemoteBlockReorderOperation) => {
+    const { socket } = get();
+    socket?.emit("reorder/block", operation);
+  },
+
   subscribeToRemoteOperations: (handlers: RemoteOperationHandlers) => {
     const { socket } = get();
     if (!socket) return;
@@ -153,6 +161,7 @@ export const useSocketStore = create<SocketStore>((set, get) => ({
     socket.on("update/block", handlers.onRemoteBlockUpdate);
     socket.on("insert/block", handlers.onRemoteBlockInsert);
     socket.on("delete/block", handlers.onRemoteBlockDelete);
+    socket.on("reorder/block", handlers.onRemoteBlockReorder);
     socket.on("insert/char", handlers.onRemoteCharInsert);
     socket.on("delete/char", handlers.onRemoteCharDelete);
     socket.on("cursor", handlers.onRemoteCursor);
@@ -161,6 +170,7 @@ export const useSocketStore = create<SocketStore>((set, get) => ({
       socket.off("update/block", handlers.onRemoteBlockUpdate);
       socket.off("insert/block", handlers.onRemoteBlockInsert);
       socket.off("delete/block", handlers.onRemoteBlockDelete);
+      socket.off("reorder/block", handlers.onRemoteBlockReorder);
       socket.off("insert/char", handlers.onRemoteCharInsert);
       socket.off("delete/char", handlers.onRemoteCharDelete);
       socket.off("cursor", handlers.onRemoteCursor);

--- a/server/src/crdt/crdt.gateway.ts
+++ b/server/src/crdt/crdt.gateway.ts
@@ -376,7 +376,7 @@ export class CrdtGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
       );
       // 1. 워크스페이스 가져오기
       const workspace = this.workSpaceService.getWorkspace();
-      
+
       const currentPage = workspace.pageList.find((p) => p.id === data.pageId);
       if (!currentPage) {
         throw new Error(`Page with id ${data.pageId} not found`);
@@ -388,7 +388,7 @@ export class CrdtGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
         targetId: data.targetId,
         beforeId: data.beforeId,
         afterId: data.afterId,
-        pageId: data.pageId
+        pageId: data.pageId,
       } as RemoteBlockReorderOperation;
       client.broadcast.emit("reorder/block", operation);
     } catch (error) {

--- a/server/src/crdt/crdt.gateway.ts
+++ b/server/src/crdt/crdt.gateway.ts
@@ -17,6 +17,7 @@ import {
   RemoteCharInsertOperation,
   RemoteBlockUpdateOperation,
   RemotePageCreateOperation,
+  RemoteBlockReorderOperation,
   CursorPosition,
 } from "@noctaCrdt/Interfaces";
 import { Logger } from "@nestjs/common";
@@ -359,6 +360,43 @@ export class CrdtGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
         error.stack,
       );
       throw new WsException(`Delete 연산 실패: ${error.message}`);
+    }
+  }
+
+  @SubscribeMessage("reorder/block")
+  async handleBlockReorder(
+    @MessageBody() data: RemoteBlockReorderOperation,
+    @ConnectedSocket() client: Socket,
+  ): Promise<void> {
+    const clientInfo = this.clientMap.get(client.id);
+    try {
+      this.logger.debug(
+        `블록 Reorder 연산 수신 - Client ID: ${clientInfo?.clientId}, Data:`,
+        JSON.stringify(data),
+      );
+      // 1. 워크스페이스 가져오기
+      const workspace = this.workSpaceService.getWorkspace();
+      
+      const currentPage = workspace.pageList.find((p) => p.id === data.pageId);
+      if (!currentPage) {
+        throw new Error(`Page with id ${data.pageId} not found`);
+      }
+      currentPage.crdt.remoteReorder(data);
+
+      // 5. 다른 클라이언트들에게 업데이트된 블록 정보 브로드캐스트
+      const operation = {
+        targetId: data.targetId,
+        beforeId: data.beforeId,
+        afterId: data.afterId,
+        pageId: data.pageId
+      } as RemoteBlockReorderOperation;
+      client.broadcast.emit("reorder/block", operation);
+    } catch (error) {
+      this.logger.error(
+        `블록 Reorder 연산 처리 중 오류 발생 - Client ID: ${clientInfo?.clientId}`,
+        error.stack,
+      );
+      throw new WsException(`Update 연산 실패: ${error.message}`);
     }
   }
 


### PR DESCRIPTION
## 📝 변경 사항

- 블록 드래그 앤 드랍 서버 반영

## 🔍 변경 사항 설명

- CRDT 라이브러리 remoteReorderOperation 타입 수정
- useBlockDragAndDrop 커스텀 훅에서 DragEnd시 서버로 연산 operation 전송
- useSocketStore에 reorder/block socket 이벤트 등록
- crdt.gateway.ts에 reorder/block 핸들러 등록

## 🙏 질문 사항

- 기존 로직에 맞게 드래그 앤 드롭도 socket으로 operation 전송해서 다른 클라이언트에 이벤트를 발생시킵니다.

## 📷 스크린샷 (선택)


https://github.com/user-attachments/assets/bffb78cf-e196-4b8e-81d6-6241e3107b4b

## ✅ 작성자 체크리스트

- [x] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [x] 로컬에서 모든 기능이 정상 작동함
- [x] 린터 및 포맷터로 코드 정리됨
- [x] 의존성 업데이트 확인
- [x] 문서 업데이트 또는 주석 추가 (필요 시)
