### PR TITLE
Feature/#042 블록에 마우스를 호버하면 한 쪽 끝에 옵션 버튼 구현

### DIFF
--- a/client/src/features/editor/components/MenuBlock/MenuBlock.style.ts
+++ b/client/src/features/editor/components/MenuBlock/MenuBlock.style.ts
@@ -9,11 +9,9 @@ export const menuBlockStyle = css({
   width: "20px",
   height: "20px",
   marginLeft: "-20px",
+  opacity: 0,
   transition: "opacity 0.2s ease-in-out",
   cursor: "grab",
-  _groupHover: {
-    opacity: 1,
-  },
   _active: {
     cursor: "grabbing",
   },

--- a/client/src/features/editor/components/MenuBlock/MenuBlock.tsx
+++ b/client/src/features/editor/components/MenuBlock/MenuBlock.tsx
@@ -71,7 +71,12 @@ export const MenuBlock = ({
   };
 
   return (
-    <div ref={menuBlockRef} className={menuBlockStyle} {...attributes} {...modifiedListeners}>
+    <div
+      ref={menuBlockRef}
+      className={`menu_block ${isOpen ? "option_modal_open" : ""} ${menuBlockStyle}`}
+      {...attributes}
+      {...modifiedListeners}
+    >
       <div className={dragHandleIconStyle}>
         <img src={DraggableIcon} alt="drag handle" width="10" height="10" />
       </div>

--- a/client/src/features/editor/components/block/Block.style.ts
+++ b/client/src/features/editor/components/block/Block.style.ts
@@ -8,6 +8,9 @@ const baseBlockStyle = {
   width: "full",
   minHeight: "16px",
   backgroundColor: "transparent",
+  "&:hover .menu_block, .menu_block.option_modal_open": {
+    opacity: 1,
+  },
 };
 
 export const blockContainerStyle = cva({


### PR DESCRIPTION
- #042

## 📝 변경 사항

https://github.com/user-attachments/assets/1ebd6706-d4cb-4a5a-90e9-d06210423cfc

- 블록에 마우스가 hover됐을때 해당블록의 menuBlock이 보입니다.

## 🔍 변경 사항 설명

- menu_block 이란 클래스와, option_modal_open 클래스를 추가하여 block.style.ts에 반영했습니다.

## 🙏 질문 사항

- [ ] 클래스 네이밍을 직접 정해주는게 pandaCSS에서 사용해도 되나 싶긴합니다. 만약 틀렸다면 추후 맞는 컨벤션으로 수정하겠습니다!

## 📷 스크린샷 (선택)

- UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

## ✅ 작성자 체크리스트

- [x] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [x] 로컬에서 모든 기능이 정상 작동함
- [x] 린터 및 포맷터로 코드 정리됨
- [x] 의존성 업데이트 확인
- [ ] 문서 업데이트 또는 주석 추가 (필요 시)
