### PR TITLE
Feature/#181 socketStore에 accessToken의존성 부여

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -20,13 +20,13 @@ const App = () => {
 
   useEffect(() => {
     const socketStore = useSocketStore.getState();
-    socketStore.init();
+    socketStore.init(accessToken);
     return () => {
       setTimeout(() => {
         socketStore.cleanup();
       }, 0);
     };
-  }, []);
+  }, [accessToken]);
 
   return (
     <>

--- a/client/src/stores/useSocketStore.ts
+++ b/client/src/stores/useSocketStore.ts
@@ -16,7 +16,7 @@ interface SocketStore {
   socket: Socket | null;
   clientId: number | null;
   workspace: WorkSpaceSerializedProps | null;
-  init: () => void;
+  init: (accessToken: string | null) => void;
   cleanup: () => void;
   fetchWorkspaceData: () => WorkSpaceSerializedProps | null;
   sendPageCreateOperation: (operation: RemotePageCreateOperation) => void;
@@ -51,9 +51,8 @@ export const useSocketStore = create<SocketStore>((set, get) => ({
   clientId: null,
   workspace: null,
 
-  init: () => {
+  init: (accessToken: string | null) => {
     const { socket: existingSocket } = get();
-    if (existingSocket?.connected) return;
 
     if (existingSocket) {
       existingSocket.disconnect();
@@ -68,6 +67,9 @@ export const useSocketStore = create<SocketStore>((set, get) => ({
       withCredentials: true,
       reconnectionAttempts: 5,
       reconnectionDelay: 1000,
+      auth: {
+        token: accessToken,
+      },
       autoConnect: false,
     });
 


### PR DESCRIPTION
- #181

## 📝 변경 사항

https://github.com/user-attachments/assets/f5e3bdfe-971b-4985-b554-780150165fed
- 로그인/로그아웃 할때 워크스페이스가 갱신됨.

- socket 생성때 auth에서 사용한 accessToken을 활용
- null 일경우 guestWorkspace를 표현할 예정



## 🔍 변경 사항 설명

- socketStore가 실행될때, JWT 에서 사용되는 accessToken을 가져오고 여기에 의존성을 부여합니다.
- 기존에 
```js
if(socket?.connected)  return;
```
를 삭제했습니다. -> 소켓이 연결돼있으면 더이상 안하는 코드여서 삭제했습니다.

## 🙏 질문 사항

- 추후 workspace, guest 별로 workspace를 나눌때 commit 사항으로 포함해도 되지만, 먼저 dev에 붙이고 추후 socket 과 workspace연동 작업을 진행하는게 낫다고 판단하여 간단하게 PR을 올렸습니다.

## ✅ 작성자 체크리스트

- [x] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [x] 로컬에서 모든 기능이 정상 작동함
- [x] 린터 및 포맷터로 코드 정리됨
- [x] 의존성 업데이트 확인
- [ ] 문서 업데이트 또는 주석 추가 (필요 시)
