### PR TITLE
Feature/#184 페이지 삭제 구현

### DIFF
--- a/@noctaCrdt/Interfaces.ts
+++ b/@noctaCrdt/Interfaces.ts
@@ -22,6 +22,12 @@ export interface RemotePageCreateOperation {
   page?: Page;
 }
 
+export interface RemotePageDeleteOperation {
+  clientId: number;
+  workspaceId: string;
+  pageId: string;
+}
+
 export interface RemoteBlockUpdateOperation {
   node: Block;
   pageId: string;

--- a/@noctaCrdt/WorkSpace.ts
+++ b/@noctaCrdt/WorkSpace.ts
@@ -39,7 +39,17 @@ export class WorkSpace {
     this.pageList.push(newPage);
     return newPage;
   }
+  remotePageDelete(operation: { pageId: string; workspaceId: string; clientId: number }): void {
+    const { pageId } = operation;
 
+    // pageList에서 해당 페이지의 인덱스 찾기
+    const pageIndex = this.pageList.findIndex((page) => page.id === pageId);
+
+    // 페이지가 존재하면 삭제
+    if (pageIndex !== -1) {
+      this.pageList.splice(pageIndex, 1);
+    }
+  }
   getPage(data: string) {
     const page = this.pageList.find((page) => page.id === data);
     return page;

--- a/client/src/components/sidebar/PageItem.style.ts
+++ b/client/src/components/sidebar/PageItem.style.ts
@@ -10,9 +10,29 @@ export const pageItemContainer = css({
   "&:hover": {
     background: "white/50",
     cursor: "pointer",
+    "& .delete_box": {
+      visibility: "visible",
+      opacity: 1,
+    },
   },
 });
-
+export const deleteBox = css({
+  display: "flex",
+  visibility: "hidden",
+  position: "absolute",
+  right: "md",
+  justifyContent: "center",
+  alignItems: "center",
+  borderRadius: "xs",
+  width: "24px",
+  height: "24px",
+  opacity: 0,
+  transition: "all 0.2s ease-in-out",
+  cursor: "pointer",
+  "&:hover": {
+    background: "gray.100",
+  },
+});
 export const iconBox = css({
   display: "flex",
   flexShrink: 0,

--- a/client/src/components/sidebar/PageItem.tsx
+++ b/client/src/components/sidebar/PageItem.tsx
@@ -1,17 +1,28 @@
-import { pageItemContainer, iconBox, textBox } from "./PageItem.style";
+import CloseIcon from "@assets/icons/close.svg?react";
+import { pageItemContainer, iconBox, textBox, deleteBox } from "./PageItem.style";
 
 interface PageItemProps {
   id: string;
   title: string;
   icon?: string;
   onClick: () => void;
+  onDelete?: (id: string) => void; // 추가: 삭제 핸들러
 }
 
-export const PageItem = ({ icon, title, onClick }: PageItemProps) => {
+export const PageItem = ({ id, icon, title, onClick, onDelete }: PageItemProps) => {
+  // 삭제 버튼 클릭 핸들러
+  const handleDelete = (e: React.MouseEvent) => {
+    e.stopPropagation(); // 상위 요소로의 이벤트 전파 중단
+    onDelete?.(id);
+  };
+
   return (
     <div className={pageItemContainer} onClick={onClick}>
       <span className={iconBox}>{icon}</span>
       <span className={textBox}>{title}</span>
+      <span className={`delete_box ${deleteBox}`} onClick={handleDelete}>
+        <CloseIcon width={16} height={16} />
+      </span>
     </div>
   );
 };

--- a/client/src/components/sidebar/Sidebar.style.ts
+++ b/client/src/components/sidebar/Sidebar.style.ts
@@ -33,7 +33,12 @@ export const plusIconBox = css({
   paddingInline: "md",
   justifyItems: "center",
 });
-
+export const placeholderMessage = css({
+  padding: "xs",
+  color: "gray.500",
+  textAlign: "center",
+  fontSize: "md",
+});
 export const sidebarToggleButton = css({
   zIndex: 10,
   position: "absolute",

--- a/client/src/components/sidebar/Sidebar.tsx
+++ b/client/src/components/sidebar/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { motion } from "framer-motion";
+import { useState } from "react";
 import { IconButton } from "@components/button/IconButton";
 import { Modal } from "@components/modal/modal";
 import { useModal } from "@components/modal/useModal";
@@ -34,6 +35,9 @@ export const Sidebar = ({
   const { isOpen, openModal, closeModal } = useModal();
   const { sendPageDeleteOperation, clientId } = useSocketStore();
 
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [pageToDelete, setPageToDelete] = useState<Page | null>(null);
+
   const handlePageItemClick = (id: string) => {
     if (isMaxVisiblePage) {
       openModal();
@@ -63,6 +67,11 @@ export const Sidebar = ({
     });
   };
 
+  const confirmPageDelete = (page: Page) => {
+    setPageToDelete(page);
+    setIsDeleteModalOpen(true);
+  };
+
   return (
     <motion.aside
       className={sidebarContainer}
@@ -90,7 +99,7 @@ export const Sidebar = ({
               <PageItem
                 {...item}
                 onClick={() => handlePageItemClick(item.id)}
-                onDelete={() => handlePageDelete(item.id)}
+                onDelete={() => confirmPageDelete(item)}
               />
             </motion.div>
           ))
@@ -100,11 +109,33 @@ export const Sidebar = ({
         <IconButton icon="➕" onClick={handleAddPageButtonClick} size="sm" />
         <AuthButton />
       </motion.div>
+
       <Modal isOpen={isOpen} primaryButtonLabel="확인" primaryButtonOnClick={closeModal}>
         <p>
           최대 {MAX_VISIBLE_PAGE}개의 페이지만 표시할 수 있습니다
           <br />
           사용하지 않는 페이지는 닫아주세요.
+        </p>
+      </Modal>
+
+      <Modal
+        isOpen={isDeleteModalOpen}
+        primaryButtonLabel="예"
+        primaryButtonOnClick={() => {
+          if (pageToDelete) {
+            handlePageDelete(pageToDelete.id);
+            setIsDeleteModalOpen(false);
+            setPageToDelete(null);
+          }
+        }}
+        secondaryButtonLabel="아니오"
+        secondaryButtonOnClick={() => {
+          setIsDeleteModalOpen(false);
+          setPageToDelete(null);
+        }}
+      >
+        <p>
+          정말 이 <strong>{pageToDelete?.title}</strong>을(를) 삭제하시겠습니까?
         </p>
       </Modal>
     </motion.aside>

--- a/client/src/components/sidebar/Sidebar.tsx
+++ b/client/src/components/sidebar/Sidebar.tsx
@@ -77,10 +77,10 @@ export const Sidebar = ({
         <MenuButton />
       </motion.div>
       <motion.nav className={navWrapper} variants={contentVariants}>
-        {visiblePages.length === 0 ? (
+        {pages.length === 0 ? (
           <div className={placeholderMessage}>+ 버튼을 눌러 페이지를 추가하세요</div>
         ) : (
-          visiblePages.map((item) => (
+          pages?.map((item) => (
             <motion.div
               key={item.id}
               initial={animation.initial}

--- a/client/src/components/sidebar/Sidebar.tsx
+++ b/client/src/components/sidebar/Sidebar.tsx
@@ -11,24 +11,13 @@ import { useIsSidebarOpen, useSidebarActions } from "@stores/useSidebarStore";
 import { MenuButton } from "./MenuButton";
 import { PageItem } from "./PageItem";
 import { animation, contentVariants, sidebarVariants } from "./Sidebar.animation";
-import { sidebarContainer, navWrapper, plusIconBox, sidebarToggleButton } from "./Sidebar.style";
-
-const MODAL_TEXT = {
-  maxPage: (
-    <p>
-      최대 {MAX_VISIBLE_PAGE}개의 페이지만 표시할 수 있습니다
-      <br />
-      사용하지 않는 페이지는 닫아주세요.
-    </p>
-  ),
-  lastPage: (
-    <p>
-      마지막 페이지는 삭제할 수 없습니다.
-      <br />
-      최소 1개의 페이지가 필요합니다.
-    </p>
-  ),
-} as const;
+import {
+  sidebarContainer,
+  navWrapper,
+  plusIconBox,
+  sidebarToggleButton,
+  placeholderMessage,
+} from "./Sidebar.style";
 
 export const Sidebar = ({
   pages,
@@ -116,7 +105,11 @@ export const Sidebar = ({
         <AuthButton />
       </motion.div>
       <Modal isOpen={isOpen} primaryButtonLabel="확인" primaryButtonOnClick={closeModal}>
-        {isLastPageModal ? MODAL_TEXT.lastPage : MODAL_TEXT.maxPage}
+        <p>
+          최대 {MAX_VISIBLE_PAGE}개의 페이지만 표시할 수 있습니다
+          <br />
+          사용하지 않는 페이지는 닫아주세요.
+        </p>
       </Modal>
     </motion.aside>
   );

--- a/client/src/components/sidebar/Sidebar.tsx
+++ b/client/src/components/sidebar/Sidebar.tsx
@@ -1,5 +1,4 @@
 import { motion } from "framer-motion";
-import { useState } from "react";
 import { IconButton } from "@components/button/IconButton";
 import { Modal } from "@components/modal/modal";
 import { useModal } from "@components/modal/useModal";
@@ -34,7 +33,6 @@ export const Sidebar = ({
   const { toggleSidebar } = useSidebarActions();
   const { isOpen, openModal, closeModal } = useModal();
   const { sendPageDeleteOperation, clientId } = useSocketStore();
-  const [isLastPageModal, setIsLastPageModal] = useState(false);
 
   const handlePageItemClick = (id: string) => {
     if (isMaxVisiblePage) {
@@ -55,12 +53,6 @@ export const Sidebar = ({
   const handlePageDelete = (pageId: string) => {
     if (!clientId) {
       console.error("Client ID not assigned");
-      return;
-    }
-
-    if (pages.length <= 1) {
-      setIsLastPageModal(true);
-      openModal();
       return;
     }
 
@@ -85,20 +77,24 @@ export const Sidebar = ({
         <MenuButton />
       </motion.div>
       <motion.nav className={navWrapper} variants={contentVariants}>
-        {pages?.map((item) => (
-          <motion.div
-            key={item.id}
-            initial={animation.initial}
-            animate={animation.animate}
-            transition={animation.transition}
-          >
-            <PageItem
-              {...item}
-              onClick={() => handlePageItemClick(item.id)}
-              onDelete={() => handlePageDelete(item.id)}
-            />
-          </motion.div>
-        ))}
+        {visiblePages.length === 0 ? (
+          <div className={placeholderMessage}>+ 버튼을 눌러 페이지를 추가하세요</div>
+        ) : (
+          visiblePages.map((item) => (
+            <motion.div
+              key={item.id}
+              initial={animation.initial}
+              animate={animation.animate}
+              transition={animation.transition}
+            >
+              <PageItem
+                {...item}
+                onClick={() => handlePageItemClick(item.id)}
+                onDelete={() => handlePageDelete(item.id)}
+              />
+            </motion.div>
+          ))
+        )}
       </motion.nav>
       <motion.div className={plusIconBox} variants={contentVariants}>
         <IconButton icon="➕" onClick={handleAddPageButtonClick} size="sm" />

--- a/client/src/features/editor/Editor.style.ts
+++ b/client/src/features/editor/Editor.style.ts
@@ -26,7 +26,7 @@ export const editorTitle = css({
   width: "full",
   color: "gray.700",
   "&::placeholder": {
-    color: "gray.300",
+    color: "gray.100",
   },
 });
 

--- a/client/src/features/workSpace/hooks/usePagesManage.ts
+++ b/client/src/features/workSpace/hooks/usePagesManage.ts
@@ -26,6 +26,31 @@ export const usePagesManage = (workspace: WorkSpace | null, clientId: number | n
         });
         addPage(newPage);
       },
+      onRemotePageDelete: (operation) => {
+        console.log(operation, "page : 삭제 확인합니다");
+        workspace.remotePageDelete?.({
+          pageId: operation.pageId,
+          workspaceId: operation.workspaceId,
+          clientId: operation.clientId,
+        });
+
+        setPages((prevPages) => {
+          const deletedPage = prevPages.find((page) => page.id === operation.pageId);
+          const remainingPages = prevPages.filter((page) => page.id !== operation.pageId);
+
+          // 삭제된 페이지가 활성화된 상태였다면, 다른 페이지를 활성화
+          if (deletedPage?.isActive && remainingPages.length > 0) {
+            const nextActiveIndex = 0; // 첫 번째 페이지를 활성화하거나, 다른 로직으로 선택
+            remainingPages[nextActiveIndex] = {
+              ...remainingPages[nextActiveIndex],
+              isActive: true,
+              isVisible: true,
+            };
+          }
+
+          return remainingPages;
+        });
+      },
     });
 
     return () => {

--- a/client/src/features/workSpace/hooks/usePagesManage.ts
+++ b/client/src/features/workSpace/hooks/usePagesManage.ts
@@ -35,19 +35,7 @@ export const usePagesManage = (workspace: WorkSpace | null, clientId: number | n
         });
 
         setPages((prevPages) => {
-          const deletedPage = prevPages.find((page) => page.id === operation.pageId);
           const remainingPages = prevPages.filter((page) => page.id !== operation.pageId);
-
-          // 삭제된 페이지가 활성화된 상태였다면, 다른 페이지를 활성화
-          if (deletedPage?.isActive && remainingPages.length > 0) {
-            const nextActiveIndex = 0; // 첫 번째 페이지를 활성화하거나, 다른 로직으로 선택
-            remainingPages[nextActiveIndex] = {
-              ...remainingPages[nextActiveIndex],
-              isActive: true,
-              isVisible: true,
-            };
-          }
-
           return remainingPages;
         });
       },

--- a/client/src/stores/useSocketStore.ts
+++ b/client/src/stores/useSocketStore.ts
@@ -6,6 +6,7 @@ import {
   RemoteCharDeleteOperation,
   RemoteBlockUpdateOperation,
   RemoteBlockReorderOperation,
+  RemotePageDeleteOperation,
   CursorPosition,
   WorkSpaceSerializedProps,
 } from "@noctaCrdt/Interfaces";
@@ -20,6 +21,7 @@ interface SocketStore {
   cleanup: () => void;
   fetchWorkspaceData: () => WorkSpaceSerializedProps | null;
   sendPageCreateOperation: (operation: RemotePageCreateOperation) => void;
+  sendPageDeleteOperation: (operation: RemotePageDeleteOperation) => void;
   sendBlockUpdateOperation: (operation: RemoteBlockUpdateOperation) => void;
   sendBlockInsertOperation: (operation: RemoteBlockInsertOperation) => void;
   sendCharInsertOperation: (operation: RemoteCharInsertOperation) => void;
@@ -44,6 +46,7 @@ interface RemoteOperationHandlers {
 
 interface PageOperationsHandlers {
   onRemotePageCreate: (operation: RemotePageCreateOperation) => void;
+  onRemotePageDelete: (operation: RemotePageDeleteOperation) => void;
 }
 
 export const useSocketStore = create<SocketStore>((set, get) => ({
@@ -115,7 +118,11 @@ export const useSocketStore = create<SocketStore>((set, get) => ({
     socket?.emit("create/page", operation);
     console.log("페이지 만들기 송신", operation);
   },
-
+  sendPageDeleteOperation: (operation: RemotePageDeleteOperation) => {
+    const { socket } = get();
+    socket?.emit("delete/page", operation);
+    console.log("페이지 삭제 송신", operation);
+  },
   sendBlockInsertOperation: (operation: RemoteBlockInsertOperation) => {
     const { socket } = get();
     console.log("block insert operation", operation);
@@ -181,8 +188,10 @@ export const useSocketStore = create<SocketStore>((set, get) => ({
     const { socket } = get();
     if (!socket) return;
     socket.on("create/page", handlers.onRemotePageCreate);
+    socket.on("delete/page", handlers.onRemotePageDelete);
     return () => {
       socket.off("create/page", handlers.onRemotePageCreate);
+      socket.off("delete/page", handlers.onRemotePageDelete);
     };
   },
 }));

--- a/server/src/crdt/crdt.gateway.ts
+++ b/server/src/crdt/crdt.gateway.ts
@@ -115,7 +115,7 @@ export class CrdtGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
   }
 
   /**
-   * 블록 삽입 연산 처리
+   * 페이지 삽입 연산 처리
    */
   @SubscribeMessage("create/page")
   async handlePageCreate(
@@ -154,6 +154,55 @@ export class CrdtGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
       throw new WsException(`Page Create 연산 실패: ${error.message}`);
     }
   }
+
+  /**
+   * 페이지 삭제 연산 처리
+   */
+  @SubscribeMessage("delete/page")
+  async handlePageDelete(
+    @MessageBody() data: { workspaceId: string; pageId: string; clientId: number },
+    @ConnectedSocket() client: Socket,
+  ): Promise<void> {
+    const clientInfo = this.clientMap.get(client.id);
+    try {
+      this.logger.debug(
+        `Page delete 연산 수신 - Client ID: ${clientInfo?.clientId}, Data:`,
+        JSON.stringify(data),
+      );
+
+      // 현재 워크스페이스 가져오기
+      const currentWorkspace = this.workSpaceService.getWorkspace();
+
+      // pageList에서 해당 페이지 찾기
+      const pageIndex = currentWorkspace.pageList.findIndex((page) => page.id === data.pageId);
+
+      if (pageIndex === -1) {
+        throw new Error(`Page with id ${data.pageId} not found`);
+      }
+
+      // pageList에서 페이지 제거
+      currentWorkspace.pageList.splice(pageIndex, 1);
+
+      const operation = {
+        workspaceId: data.workspaceId,
+        pageId: data.pageId,
+        clientId: data.clientId,
+      };
+
+      // 삭제 이벤트를 모든 클라이언트에게 브로드캐스트
+      client.emit("delete/page", operation);
+      client.broadcast.emit("delete/page", operation);
+
+      this.logger.debug(`Page ${data.pageId} successfully deleted`);
+    } catch (error) {
+      this.logger.error(
+        `Page Delete 연산 처리 중 오류 발생 - Client ID: ${clientInfo?.clientId}`,
+        error.stack,
+      );
+      throw new WsException(`Page Delete 연산 실패: ${error.message}`);
+    }
+  }
+
   /**
    * 블록 업데이트 연산 처리
    */


### PR DESCRIPTION
## 📝 변경 사항

https://github.com/user-attachments/assets/9b567571-d119-4857-abb4-17a21b43d068


- 페이지 아이템에 마우스를 hover시, close 아이콘을 표시합니다.
- close 아이콘을 클릭 시, 페이지를 삭제합니다.
  - deleteOperation 추가
  - delete/page 추가

## 🔍 변경 사항 설명

- create/page 처럼 delete/page를 추가하였습니다.
- 최소 1개 페이지가 남기게 변경하였습니다.

## 🙏 질문 사항

- [ ] 최소 1개 페이지를 굳이 남겨야할까? 라는 생각이 있긴 합니다... 여러분들의 의견이 궁금합니다 !!
- [ ] 삭제 하기 전에 페이지를 삭제할까요? 모달창을 띄울까 생각중입니다. 아무래도 필요해 보이네요.. 곧 수정하겠습니다.

- 추후 broadcast 하는부분이 전부 to(userId) 로 바뀔예정인데, 일단 broadcast로 작업하겠습니다.
- 그리고 workspace연동 PR에서 이 PR을 pull 해서 변경사항을 반영하여 다시 PR올리겠습니다.!

## 📷 스크린샷 (선택)

- UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

## ✅ 작성자 체크리스트

- [x] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [x] 로컬에서 모든 기능이 정상 작동함
- [x] 린터 및 포맷터로 코드 정리됨
- [x] 의존성 업데이트 확인
- [ ] 문서 업데이트 또는 주석 추가 (필요 시)
