### PR TITLE
Feature/#053 블럭내 복사 붙여넣기 구현

### DIFF
--- a/@noctaCrdt/Crdt.ts
+++ b/@noctaCrdt/Crdt.ts
@@ -230,6 +230,7 @@ export class BlockCRDT extends CRDT<Char> {
       node,
       blockId,
       pageId,
+      style: node.style || [],
     };
 
     return operation;
@@ -270,6 +271,12 @@ export class BlockCRDT extends CRDT<Char> {
 
     newNode.next = operation.node.next;
     newNode.prev = operation.node.prev;
+
+    if (operation.style && operation.style.length > 0) {
+      operation.style.forEach((style) => {
+        newNode.style.push(style);
+      });
+    }
 
     this.LinkedList.insertById(newNode);
 

--- a/@noctaCrdt/Crdt.ts
+++ b/@noctaCrdt/Crdt.ts
@@ -10,6 +10,8 @@ import {
   RemoteBlockReorderOperation,
   RemoteBlockUpdateOperation,
   RemoteCharUpdateOperation,
+  TextColorType,
+  BackgroundColorType,
 } from "./Interfaces";
 
 export class CRDT<T extends Node<NodeId>> {
@@ -219,11 +221,19 @@ export class BlockCRDT extends CRDT<Char> {
     blockId: BlockId,
     pageId: string,
     style?: string[],
+    color?: TextColorType,
+    backgroundColor?: BackgroundColorType,
   ): RemoteCharInsertOperation {
     const id = new CharId(this.clock + 1, this.client);
     const { node } = this.LinkedList.insertAtIndex(index, value, id) as { node: Char };
     if (style && style.length > 0) {
       node.style = style;
+    }
+    if (color) {
+      node.color = color;
+    }
+    if (backgroundColor) {
+      node.backgroundColor = backgroundColor;
     }
     this.clock += 1;
     const operation: RemoteCharInsertOperation = {

--- a/@noctaCrdt/Crdt.ts
+++ b/@noctaCrdt/Crdt.ts
@@ -261,7 +261,15 @@ export class BlockCRDT extends CRDT<Char> {
 
   localUpdate(node: Char, blockId: BlockId, pageId: string): RemoteCharUpdateOperation {
     const updatedChar = this.LinkedList.nodeMap[JSON.stringify(node.id)];
-    updatedChar.style = [...node.style];
+    if (node.style && node.style.length > 0) {
+      updatedChar.style = [...node.style];
+    }
+    if (node.color) {
+      updatedChar.color = node.color;
+    }
+    if (node.backgroundColor !== updatedChar.backgroundColor) {
+      updatedChar.backgroundColor = node.backgroundColor;
+    }
     return { node: updatedChar, blockId, pageId };
   }
 
@@ -298,7 +306,15 @@ export class BlockCRDT extends CRDT<Char> {
 
   remoteUpdate(operation: RemoteCharUpdateOperation): void {
     const updatedChar = this.LinkedList.nodeMap[JSON.stringify(operation.node.id)];
-    updatedChar.style = [...operation.node.style];
+    if (operation.node.style && operation.node.style.length > 0) {
+      updatedChar.style = [...operation.node.style];
+    }
+    if (operation.node.color) {
+      updatedChar.color = operation.node.color;
+    }
+    if (operation.node.backgroundColor) {
+      updatedChar.backgroundColor = operation.node.backgroundColor;
+    }
   }
 
   serialize(): CRDTSerializedProps<Char> {

--- a/@noctaCrdt/Crdt.ts
+++ b/@noctaCrdt/Crdt.ts
@@ -218,9 +218,13 @@ export class BlockCRDT extends CRDT<Char> {
     value: string,
     blockId: BlockId,
     pageId: string,
+    style?: string[],
   ): RemoteCharInsertOperation {
     const id = new CharId(this.clock + 1, this.client);
     const { node } = this.LinkedList.insertAtIndex(index, value, id) as { node: Char };
+    if (style && style.length > 0) {
+      node.style = style;
+    }
     this.clock += 1;
     const operation: RemoteCharInsertOperation = {
       node,

--- a/@noctaCrdt/Crdt.ts
+++ b/@noctaCrdt/Crdt.ts
@@ -296,6 +296,14 @@ export class BlockCRDT extends CRDT<Char> {
       });
     }
 
+    if (operation.color) {
+      newNode.color = operation.color;
+    }
+
+    if (operation.backgroundColor) {
+      newNode.backgroundColor = operation.backgroundColor;
+    }
+
     this.LinkedList.insertById(newNode);
 
     if (this.clock <= newNode.id.clock) {

--- a/@noctaCrdt/Interfaces.ts
+++ b/@noctaCrdt/Interfaces.ts
@@ -7,6 +7,8 @@ export type ElementType = "p" | "h1" | "h2" | "h3" | "ul" | "ol" | "li" | "check
 
 export type AnimationType = "none" | "highlight" | "gradation";
 
+export type TextStyleType = "bold" | "italic" | "underline" | "strikethrough";
+
 export interface InsertOperation {
   node: Block | Char;
 }
@@ -48,6 +50,12 @@ export interface RemoteCharDeleteOperation {
   targetId: CharId;
   clock: number;
   blockId?: BlockId;
+  pageId: string;
+}
+
+export interface RemoteCharUpdateOperation {
+  node: Char;
+  blockId: BlockId;
   pageId: string;
 }
 

--- a/@noctaCrdt/Interfaces.ts
+++ b/@noctaCrdt/Interfaces.ts
@@ -9,6 +9,19 @@ export type AnimationType = "none" | "highlight" | "gradation";
 
 export type TextStyleType = "bold" | "italic" | "underline" | "strikethrough";
 
+export type BackgroundColorType =
+  | "black"
+  | "red"
+  | "green"
+  | "blue"
+  | "white"
+  | "yellow"
+  | "purple"
+  | "brown"
+  | "transparent";
+
+export type TextColorType = Exclude<BackgroundColorType, "transparent">;
+
 export interface InsertOperation {
   node: Block | Char;
 }

--- a/@noctaCrdt/Interfaces.ts
+++ b/@noctaCrdt/Interfaces.ts
@@ -52,6 +52,8 @@ export interface RemoteCharInsertOperation {
   blockId: BlockId;
   pageId: string;
   style?: string[];
+  color?: TextColorType;
+  backgroundColor?: BackgroundColorType;
 }
 
 export interface RemoteBlockDeleteOperation {

--- a/@noctaCrdt/Interfaces.ts
+++ b/@noctaCrdt/Interfaces.ts
@@ -38,6 +38,7 @@ export interface RemoteCharInsertOperation {
   node: Char;
   blockId: BlockId;
   pageId: string;
+  style?: string[];
 }
 
 export interface RemoteBlockDeleteOperation {

--- a/@noctaCrdt/LinkedList.ts
+++ b/@noctaCrdt/LinkedList.ts
@@ -219,6 +219,35 @@ export abstract class LinkedList<T extends Node<NodeId>> {
     this.setNode(node.id, node);
   }
 
+  getNodesBetween(startIndex: number, endIndex: number): T[] {
+    if (startIndex < 0 || endIndex < startIndex) {
+      throw new Error("Invalid indices");
+    }
+
+    const result: T[] = [];
+    let currentNodeId = this.head;
+    let currentIndex = 0;
+
+    // 시작 인덱스까지 이동
+    while (currentNodeId !== null && currentIndex < startIndex) {
+      const currentNode = this.getNode(currentNodeId);
+      if (!currentNode) break;
+      currentNodeId = currentNode.next;
+      currentIndex += 1;
+    }
+
+    // 시작 인덱스부터 끝 인덱스까지의 노드들 수집
+    while (currentNodeId !== null && currentIndex < endIndex) {
+      const currentNode = this.getNode(currentNodeId);
+      if (!currentNode) break;
+      result.push(currentNode);
+      currentNodeId = currentNode.next;
+      currentIndex += 1;
+    }
+
+    return result;
+  }
+
   stringify(): string {
     let currentNodeId = this.head;
     let result = "";
@@ -244,27 +273,6 @@ export abstract class LinkedList<T extends Node<NodeId>> {
     }
     return result;
   }
-
-  /*
-  spread(): T[] {
-    const visited = new Set<string>();
-    let currentNodeId = this.head;
-    const result: T[] = [];
-    
-    while (currentNodeId !== null) {
-      const nodeKey = JSON.stringify(currentNodeId);
-      if (visited.has(nodeKey)) break; // 순환 감지
-      
-      visited.add(nodeKey);
-      const currentNode = this.getNode(currentNodeId);
-      if (!currentNode) break;
-      
-      result.push(currentNode);
-      currentNodeId = currentNode.next;
-    }
-    return result;
-}
-  */
 
   serialize(): any {
     return {

--- a/@noctaCrdt/LinkedList.ts
+++ b/@noctaCrdt/LinkedList.ts
@@ -144,7 +144,7 @@ export abstract class LinkedList<T extends Node<NodeId>> {
     return node;
   }
 
-  insertAtIndex(index: number, value: string, id: T["id"]): InsertOperation {
+  insertAtIndex(index: number, value: string, id: T["id"]) {
     try {
       const node = this.createNode(value, id);
       this.setNode(id, node);

--- a/@noctaCrdt/Node.ts
+++ b/@noctaCrdt/Node.ts
@@ -1,6 +1,6 @@
 // Node.ts
 import { NodeId, BlockId, CharId } from "./NodeId";
-import { AnimationType, ElementType } from "./Interfaces";
+import { AnimationType, ElementType, TextStyleType } from "./Interfaces";
 import { BlockCRDT } from "./Crdt";
 
 export abstract class Node<T extends NodeId> {
@@ -86,8 +86,11 @@ export class Block extends Node<BlockId> {
 }
 
 export class Char extends Node<CharId> {
+  style: TextStyleType[];
+
   constructor(value: string, id: CharId) {
     super(value, id);
+    this.style = [];
   }
 
   serialize(): any {
@@ -99,6 +102,7 @@ export class Char extends Node<CharId> {
     const char = new Char(data.value, id);
     char.next = data.next ? CharId.deserialize(data.next) : null;
     char.prev = data.prev ? CharId.deserialize(data.prev) : null;
+    char.style = data.style ? data.style : [];
     return char;
   }
 }

--- a/@noctaCrdt/Node.ts
+++ b/@noctaCrdt/Node.ts
@@ -1,6 +1,6 @@
 // Node.ts
 import { NodeId, BlockId, CharId } from "./NodeId";
-import { AnimationType, ElementType } from "./Interfaces";
+import { AnimationType, ElementType, TextColorType, BackgroundColorType } from "./Interfaces";
 import { BlockCRDT } from "./Crdt";
 
 export abstract class Node<T extends NodeId> {
@@ -90,14 +90,22 @@ export class Block extends Node<BlockId> {
 
 export class Char extends Node<CharId> {
   style: string[];
+  color: TextColorType;
+  backgroundColor: BackgroundColorType;
 
   constructor(value: string, id: CharId) {
     super(value, id);
     this.style = [];
+    this.color = "black";
+    this.backgroundColor = "transparent";
   }
 
   serialize(): any {
-    return super.serialize();
+    return {
+      ...super.serialize(),
+      color: this.color,
+      backgroundColor: this.backgroundColor,
+    };
   }
 
   static deserialize(data: any): Char {
@@ -106,6 +114,8 @@ export class Char extends Node<CharId> {
     char.next = data.next ? CharId.deserialize(data.next) : null;
     char.prev = data.prev ? CharId.deserialize(data.prev) : null;
     char.style = data.style ? data.style : [];
+    char.color = data.color ? data.color : "black";
+    char.backgroundColor = data.backgroundColor ? data.backgroundColor : "transparent";
     return char;
   }
 }

--- a/@noctaCrdt/Node.ts
+++ b/@noctaCrdt/Node.ts
@@ -8,12 +8,14 @@ export abstract class Node<T extends NodeId> {
   value: string;
   next: T | null;
   prev: T | null;
+  style: string[];
 
   constructor(value: string, id: T) {
     this.id = id;
     this.value = value;
     this.next = null;
     this.prev = null;
+    this.style = [];
   }
 
   precedes(node: Node<T>): boolean {
@@ -32,6 +34,7 @@ export abstract class Node<T extends NodeId> {
       value: this.value,
       next: this.next ? this.next.serialize() : null,
       prev: this.prev ? this.prev.serialize() : null,
+      style: this.style,
     };
   }
 
@@ -86,7 +89,7 @@ export class Block extends Node<BlockId> {
 }
 
 export class Char extends Node<CharId> {
-  style: TextStyleType[];
+  style: string[];
 
   constructor(value: string, id: CharId) {
     super(value, id);

--- a/@noctaCrdt/Node.ts
+++ b/@noctaCrdt/Node.ts
@@ -1,6 +1,6 @@
 // Node.ts
 import { NodeId, BlockId, CharId } from "./NodeId";
-import { AnimationType, ElementType, TextStyleType } from "./Interfaces";
+import { AnimationType, ElementType } from "./Interfaces";
 import { BlockCRDT } from "./Crdt";
 
 export abstract class Node<T extends NodeId> {

--- a/client/package.json
+++ b/client/package.json
@@ -33,6 +33,7 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.3",
+    "dompurify": "^3.2.1",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jsx-a11y": "^6.8.0",
     "eslint-plugin-react": "^7.33.2",

--- a/client/src/constants/color.ts
+++ b/client/src/constants/color.ts
@@ -9,4 +9,7 @@ export const COLOR = {
   RED: "#F24150",
   YELLOW: "#FEA642",
   GREEN: "#1BBF44",
+  PURPLE: "#A142FE",
+  BROWN: "#8B4513",
+  BLUE: "#4285F4",
 };

--- a/client/src/constants/option.ts
+++ b/client/src/constants/option.ts
@@ -1,4 +1,4 @@
-import { AnimationType, ElementType } from "@noctaCrdt/Interfaces";
+import { AnimationType, ElementType, TextStyleType } from "@noctaCrdt/Interfaces";
 
 export const OPTION_CATEGORIES = {
   TYPE: {
@@ -36,4 +36,18 @@ export const OPTION_CATEGORIES = {
   },
 };
 
+export const TEXT_OPTION_CATEGORIES = {
+  TYPE: {
+    id: "textType",
+    label: "글자",
+    options: [
+      { id: "bold", label: "굵게" },
+      { id: "italic", label: "기울임" },
+      { id: "underline", label: "밑줄" },
+      { id: "strikethrough", label: "취소선" },
+    ] as { id: TextStyleType; label: string }[],
+  },
+};
+
 export type OptionCategory = keyof typeof OPTION_CATEGORIES;
+export type TextOptionCategory = keyof typeof TEXT_OPTION_CATEGORIES;

--- a/client/src/features/editor/Editor.tsx
+++ b/client/src/features/editor/Editor.tsx
@@ -7,6 +7,8 @@ import { BlockId } from "@noctaCrdt/NodeId";
 import {
   RemoteCharInsertOperation,
   serializedEditorDataProps,
+  TextColorType,
+  BackgroundColorType,
 } from "node_modules/@noctaCrdt/Interfaces.ts";
 import { useRef, useState, useCallback, useEffect, useMemo } from "react";
 import { useSocketStore } from "@src/stores/useSocketStore.ts";
@@ -22,6 +24,12 @@ import { useBlockDragAndDrop } from "./hooks/useBlockDragAndDrop";
 import { useBlockOptionSelect } from "./hooks/useBlockOption.ts";
 import { useMarkdownGrammer } from "./hooks/useMarkdownGrammer";
 import { useTextOptionSelect } from "./hooks/useTextOptions.ts";
+import { getTextOffset } from "./utils/domSyncUtils.ts";
+
+export interface EditorStateProps {
+  clock: number;
+  linkedList: BlockLinkedList;
+}
 
 interface EditorProps {
   onTitleChange: (title: string) => void;
@@ -29,10 +37,13 @@ interface EditorProps {
   serializedEditorData: serializedEditorDataProps;
 }
 
-export interface EditorStateProps {
-  clock: number;
-  linkedList: BlockLinkedList;
+interface ClipboardMetadata {
+  value: string;
+  style: string[];
+  color: TextColorType | undefined;
+  backgroundColor: BackgroundColorType | undefined;
 }
+
 // TODO: pageId, editorCRDT를 props로 받아와야함
 export const Editor = ({ onTitleChange, pageId, serializedEditorData }: EditorProps) => {
   const {
@@ -171,27 +182,98 @@ export const Editor = ({ onTitleChange, pageId, serializedEditorData }: EditorPr
     [sendCharInsertOperation, sendCharDeleteOperation],
   );
 
+  const handleCopy = (
+    e: React.ClipboardEvent<HTMLDivElement>,
+    blockRef: HTMLDivElement | null,
+    block: CRDTBlock,
+  ) => {
+    e.preventDefault();
+    if (!blockRef) return;
+
+    const selection = window.getSelection();
+    if (!selection || selection.isCollapsed || !blockRef) return;
+
+    const range = selection.getRangeAt(0);
+    if (!blockRef.contains(range.commonAncestorContainer)) return;
+
+    // 선택된 텍스트의 시작과 끝 위치 계산
+    const startOffset = getTextOffset(blockRef, range.startContainer, range.startOffset);
+    const endOffset = getTextOffset(blockRef, range.endContainer, range.endOffset);
+
+    // 선택된 텍스트와 스타일 정보 추출
+    const selectedChars = block.crdt.LinkedList.spread().slice(startOffset, endOffset);
+
+    // 커스텀 데이터 포맷으로 저장
+    const customData = {
+      text: selectedChars.map((char) => char.value).join(""),
+      metadata: selectedChars.map(
+        (char) =>
+          ({
+            value: char.value,
+            style: char.style,
+            color: char.color,
+            backgroundColor: char.backgroundColor,
+          }) as ClipboardMetadata,
+      ),
+    };
+
+    // 일반 텍스트와 커스텀 데이터 모두 클립보드에 저장
+    e.clipboardData.setData("text/plain", customData.text);
+    e.clipboardData.setData("application/x-nocta-formatted", JSON.stringify(customData));
+  };
+
   const handlePaste = (e: React.ClipboardEvent<HTMLDivElement>, block: CRDTBlock) => {
     e.preventDefault();
-    const text = e.clipboardData.getData("text/plain");
 
-    if (!block || text.length === 0) return;
+    const customData = e.clipboardData.getData("application/x-nocta-formatted");
 
-    const caretPosition = block.crdt.currentCaret;
+    if (customData) {
+      const { metadata } = JSON.parse(customData);
+      const caretPosition = block.crdt.currentCaret;
 
-    // 텍스트를 한 글자씩 순차적으로 삽입
-    text.split("").forEach((char, index) => {
-      const insertPosition = caretPosition + index;
-      const charNode = block.crdt.localInsert(insertPosition, char, block.id, pageId);
-      sendCharInsertOperation({
-        node: charNode.node,
-        blockId: block.id,
-        pageId,
+      metadata.forEach((char: ClipboardMetadata, index: number) => {
+        const insertPosition = caretPosition + index;
+        const charNode = block.crdt.localInsert(
+          insertPosition,
+          char.value,
+          block.id,
+          pageId,
+          char.style,
+          char.color,
+          char.backgroundColor,
+        );
+        sendCharInsertOperation({
+          node: charNode.node,
+          blockId: block.id,
+          pageId,
+          style: char.style,
+          color: char.color,
+          backgroundColor: char.backgroundColor,
+        });
       });
-    });
 
-    // 캐럿 위치 업데이트
-    editorCRDT.current.currentBlock!.crdt.currentCaret = caretPosition + text.length;
+      editorCRDT.current.currentBlock!.crdt.currentCaret = caretPosition + metadata.length;
+    } else {
+      const text = e.clipboardData.getData("text/plain");
+
+      if (!block || text.length === 0) return;
+
+      const caretPosition = block.crdt.currentCaret;
+
+      // 텍스트를 한 글자씩 순차적으로 삽입
+      text.split("").forEach((char, index) => {
+        const insertPosition = caretPosition + index;
+        const charNode = block.crdt.localInsert(insertPosition, char, block.id, pageId);
+        sendCharInsertOperation({
+          node: charNode.node,
+          blockId: block.id,
+          pageId,
+        });
+      });
+
+      // 캐럿 위치 업데이트
+      editorCRDT.current.currentBlock!.crdt.currentCaret = caretPosition + text.length;
+    }
 
     setEditorState({
       clock: editorCRDT.current.clock,
@@ -364,6 +446,7 @@ export const Editor = ({ onTitleChange, pageId, serializedEditorData }: EditorPr
                 onInput={handleBlockInput}
                 onCompositionEnd={handleCompositionEnd}
                 onKeyDown={handleKeyDown}
+                onCopy={handleCopy}
                 onPaste={handlePaste}
                 onClick={handleBlockClick}
                 onAnimationSelect={handleAnimationSelect}

--- a/client/src/features/editor/Editor.tsx
+++ b/client/src/features/editor/Editor.tsx
@@ -8,7 +8,7 @@ import {
   RemoteCharInsertOperation,
   serializedEditorDataProps,
 } from "node_modules/@noctaCrdt/Interfaces.ts";
-import { useRef, useState, useCallback, useEffect, useMemo, useLayoutEffect } from "react";
+import { useRef, useState, useCallback, useEffect, useMemo } from "react";
 import { useSocketStore } from "@src/stores/useSocketStore.ts";
 import { setCaretPosition, getAbsoluteCaretPosition } from "@src/utils/caretUtils.ts";
 import {

--- a/client/src/features/editor/Editor.tsx
+++ b/client/src/features/editor/Editor.tsx
@@ -319,6 +319,7 @@ export const Editor = ({ onTitleChange, pageId, serializedEditorData }: EditorPr
           onChange={handleTitleChange}
           className={editorTitle}
         />
+        <div style={{ height: "36px" }}></div>
         <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
           <SortableContext
             items={editorState.linkedList

--- a/client/src/features/editor/Editor.tsx
+++ b/client/src/features/editor/Editor.tsx
@@ -85,11 +85,13 @@ export const Editor = ({ onTitleChange, pageId, serializedEditorData }: EditorPr
     sendCharInsertOperation,
   });
 
-  const { onTextStyleUpdate } = useTextOptionSelect({
-    editorCRDT: editorCRDT.current,
-    setEditorState,
-    pageId,
-  });
+  const { onTextStyleUpdate, onTextColorUpdate, onTextBackgroundColorUpdate } = useTextOptionSelect(
+    {
+      editorCRDT: editorCRDT.current,
+      setEditorState,
+      pageId,
+    },
+  );
 
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     onTitleChange(e.target.value);
@@ -339,6 +341,8 @@ export const Editor = ({ onTitleChange, pageId, serializedEditorData }: EditorPr
                 onCopySelect={handleCopySelect}
                 onDeleteSelect={handleDeleteSelect}
                 onTextStyleUpdate={onTextStyleUpdate}
+                onTextColorUpdate={onTextColorUpdate}
+                onTextBackgroundColorUpdate={onTextBackgroundColorUpdate}
               />
             ))}
           </SortableContext>

--- a/client/src/features/editor/components/ColorOptionModal/BackgroundColorOptionModal.style.ts
+++ b/client/src/features/editor/components/ColorOptionModal/BackgroundColorOptionModal.style.ts
@@ -1,0 +1,63 @@
+import { BackgroundColorType } from "@noctaCrdt/Interfaces";
+import { css, cva } from "@styled-system/css";
+
+type ColorVariants = {
+  [K in BackgroundColorType]: { backgroundColor: string };
+};
+
+export const colorPaletteModal = css({
+  zIndex: 1001,
+  borderRadius: "4px",
+  minWidth: "120px", // 3x3 그리드를 위한 최소 너비
+  padding: "4px",
+  backgroundColor: "white",
+  boxShadow: "0 2px 8px rgba(0, 0, 0, 0.15)",
+});
+
+export const colorPaletteContainer = css({
+  display: "grid",
+  gap: "4px",
+  gridTemplateColumns: "repeat(3, 1fr)",
+  width: "100%",
+});
+
+export const colorOptionButton = css({
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  border: "none",
+  borderRadius: "4px",
+  width: "28px",
+  height: "28px",
+  margin: "0 2px",
+  padding: "2px",
+  transition: "transform 0.2s",
+  cursor: "pointer",
+  "&:hover": {
+    transform: "scale(1.1)",
+  },
+});
+
+const colorVariants: ColorVariants = {
+  transparent: { backgroundColor: "#C1D7F4" },
+  black: { backgroundColor: "#2B4158" },
+  red: { backgroundColor: "#F24150" },
+  green: { backgroundColor: "#1BBF44" },
+  blue: { backgroundColor: "#4285F4" },
+  yellow: { backgroundColor: "#FEA642" },
+  purple: { backgroundColor: "#A142FE" },
+  brown: { backgroundColor: "#8B4513" },
+  white: { backgroundColor: "#EEEEEE" },
+};
+
+export const backgroundColorIndicator = cva({
+  base: {
+    borderRadius: "3px",
+    width: "100%",
+    height: "100%",
+    transition: "all 0.2s",
+  },
+  variants: {
+    color: colorVariants,
+  },
+});

--- a/client/src/features/editor/components/ColorOptionModal/BackgroundColorOptionModal.tsx
+++ b/client/src/features/editor/components/ColorOptionModal/BackgroundColorOptionModal.tsx
@@ -1,0 +1,52 @@
+import { BackgroundColorType } from "@noctaCrdt/Interfaces";
+import {
+  backgroundColorIndicator,
+  colorOptionButton,
+  colorPaletteContainer,
+  colorPaletteModal,
+} from "./BackgroundColorOptionModal.style.ts";
+
+const COLORS: BackgroundColorType[] = [
+  "black",
+  "red",
+  "blue",
+  "green",
+  "yellow",
+  "purple",
+  "brown",
+  "white",
+  "transparent",
+];
+
+interface BackgroundColorOptionModalProps {
+  onColorSelect: (color: BackgroundColorType) => void;
+  position: { top: number; left: number };
+}
+
+export const BackgroundColorOptionModal = ({
+  onColorSelect,
+  position,
+}: BackgroundColorOptionModalProps) => {
+  return (
+    <div
+      className={colorPaletteModal}
+      style={{
+        position: "absolute",
+        top: position.top,
+        left: position.left,
+      }}
+    >
+      <div className={colorPaletteContainer}>
+        {COLORS.map((color) => (
+          <button
+            key={`bg-${color}`}
+            className={colorOptionButton}
+            onClick={() => onColorSelect(color)}
+          >
+            <div className={backgroundColorIndicator({ color })} />
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/client/src/features/editor/components/ColorOptionModal/TextColorOptionModal.style.ts
+++ b/client/src/features/editor/components/ColorOptionModal/TextColorOptionModal.style.ts
@@ -1,0 +1,65 @@
+import { TextColorType } from "@noctaCrdt/Interfaces";
+import { css, cva } from "@styled-system/css";
+
+type ColorVariants = {
+  [K in TextColorType]: { color: string };
+};
+
+export const colorPaletteModal = css({
+  zIndex: 1001,
+  borderRadius: "4px",
+  minWidth: "120px", // 3x3 그리드를 위한 최소 너비
+  padding: "4px",
+  backgroundColor: "white",
+  boxShadow: "0 2px 8px rgba(0, 0, 0, 0.15)",
+});
+
+export const colorPaletteContainer = css({
+  display: "grid",
+  gap: "4px",
+  gridTemplateColumns: "repeat(3, 1fr)",
+  width: "100%",
+});
+
+export const colorOptionButton = css({
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  border: "none",
+  borderRadius: "4px",
+  width: "28px",
+  height: "28px",
+  margin: "0 2px",
+  padding: "2px",
+  transition: "transform 0.2s",
+  cursor: "pointer",
+  "&:hover": {
+    transform: "scale(1.1)",
+  },
+});
+
+const colorVariants: ColorVariants = {
+  black: { color: "#2B4158" },
+  red: { color: "#F24150" },
+  green: { color: "#1BBF44" },
+  blue: { color: "#4285F4" },
+  yellow: { color: "#FEA642" },
+  purple: { color: "#A142FE" },
+  brown: { color: "#8B4513" },
+  white: { color: "#C1D7F4" },
+};
+
+export const textColorIndicator = cva({
+  base: {
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    width: "100%",
+    height: "100%",
+    fontSize: "16px",
+    fontWeight: "bold",
+  },
+  variants: {
+    color: colorVariants,
+  },
+});

--- a/client/src/features/editor/components/ColorOptionModal/TextColorOptionModal.tsx
+++ b/client/src/features/editor/components/ColorOptionModal/TextColorOptionModal.tsx
@@ -1,0 +1,48 @@
+import { TextColorType } from "@noctaCrdt/Interfaces";
+import {
+  colorOptionButton,
+  colorPaletteContainer,
+  colorPaletteModal,
+  textColorIndicator,
+} from "./TextColorOptionModal.style.ts";
+
+const COLORS: TextColorType[] = [
+  "black",
+  "red",
+  "blue",
+  "green",
+  "yellow",
+  "purple",
+  "brown",
+  "white",
+];
+
+interface TextColorOptionModalProps {
+  onColorSelect: (color: TextColorType) => void;
+  position: { top: number; left: number };
+}
+
+export const TextColorOptionModal = ({ onColorSelect, position }: TextColorOptionModalProps) => {
+  return (
+    <div
+      className={colorPaletteModal}
+      style={{
+        position: "absolute",
+        top: position.top,
+        left: position.left,
+      }}
+    >
+      <div className={colorPaletteContainer}>
+        {COLORS.map((color) => (
+          <button
+            key={`text-${color}`}
+            className={colorOptionButton}
+            onClick={() => onColorSelect(color)}
+          >
+            <span className={textColorIndicator({ color })}>A</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/client/src/features/editor/components/TextOptionModal/TextOptionModal.style.ts
+++ b/client/src/features/editor/components/TextOptionModal/TextOptionModal.style.ts
@@ -1,0 +1,32 @@
+import { css } from "@styled-system/css";
+
+export const optionModal = css({
+  zIndex: 1000,
+  position: "fixed",
+  borderRadius: "4px",
+  background: "white",
+  boxShadow: "0 2px 8px rgba(0, 0, 0, 0.15)",
+});
+
+export const modalContainer = css({
+  display: "flex",
+  gap: "4px",
+  padding: "8px",
+});
+
+export const optionButton = css({
+  display: "flex",
+  justifyContent: "center",
+
+  alignItems: "center",
+  border: "none",
+  borderRadius: "4px",
+  minWidth: "28px",
+  height: "28px",
+  padding: "4px 8px",
+  background: "#f5f5f5",
+  cursor: "pointer",
+  "&:hover": {
+    background: "#e0e0e0",
+  },
+});

--- a/client/src/features/editor/components/TextOptionModal/TextOptionModal.style.ts
+++ b/client/src/features/editor/components/TextOptionModal/TextOptionModal.style.ts
@@ -1,4 +1,23 @@
-import { css } from "@styled-system/css";
+/* eslint-disable @pandacss/no-dynamic-styling */
+import { TextColorType } from "@noctaCrdt/Interfaces";
+import { colors } from "@src/styles/tokens/color";
+import { css, cva } from "@styled-system/css";
+import { token } from "@styled-system/tokens";
+
+type ColorVariants = {
+  [K in TextColorType]: { color: string };
+};
+
+const colorVariants: ColorVariants = {
+  black: { color: "#2B4158" },
+  red: { color: "#F24150" },
+  green: { color: "#1BBF44" },
+  blue: { color: "#4285F4" },
+  yellow: { color: "#FEA642" },
+  purple: { color: "#A142FE" },
+  brown: { color: "#8B4513" },
+  white: { color: "#C1D7F4" },
+};
 
 export const optionModal = css({
   zIndex: 1000,
@@ -28,5 +47,69 @@ export const optionButton = css({
   cursor: "pointer",
   "&:hover": {
     background: "#e0e0e0",
+  },
+});
+
+export const divider = css({
+  width: "1px",
+  height: "20px",
+  margin: "0 8px",
+});
+
+export const colorOptionButton = css({
+  width: "28px",
+  height: "28px",
+  margin: "0 2px",
+  cursor: "pointer",
+  _hover: {
+    transform: "scale(1.1)",
+  },
+});
+
+// 색상 표시 원형 스타일 베이스
+const colorIndicatorBase = {
+  width: "28px",
+  height: "28px",
+  borderRadius: "3px",
+  transition: "all 0.2s",
+};
+
+// 텍스트 색상 indicator
+export const textColorIndicator = cva({
+  ...colorIndicatorBase,
+  variants: {
+    color: colorVariants,
+  },
+});
+
+export const backgroundColorIndicator = cva({
+  ...colorIndicatorBase,
+  variants: {
+    color: {
+      black: {
+        backgroundColor: `color-mix(in srgb, ${token("colors.gray.900")}, white 20%)`,
+      },
+      red: {
+        backgroundColor: `color-mix(in srgb, ${token("colors.red")}, white 20%)`,
+      },
+      yellow: {
+        backgroundColor: `color-mix(in srgb, ${token("colors.yellow")}, white 20%)`,
+      },
+      green: {
+        backgroundColor: `color-mix(in srgb, ${token("colors.green")}, white 20%)`,
+      },
+      purple: {
+        backgroundColor: `color-mix(in srgb, ${token("colors.purple")}, white 20%)`,
+      },
+      brown: {
+        backgroundColor: `color-mix(in srgb, ${token("colors.brown")}, white 20%)`,
+      },
+      blue: {
+        backgroundColor: `color-mix(in srgb, ${token("colors.blue")}, white 20%)`,
+      },
+      white: {
+        backgroundColor: token("colors.white"),
+      },
+    },
   },
 });

--- a/client/src/features/editor/components/TextOptionModal/TextOptionModal.style.ts
+++ b/client/src/features/editor/components/TextOptionModal/TextOptionModal.style.ts
@@ -1,23 +1,4 @@
-/* eslint-disable @pandacss/no-dynamic-styling */
-import { TextColorType } from "@noctaCrdt/Interfaces";
-import { colors } from "@src/styles/tokens/color";
-import { css, cva } from "@styled-system/css";
-import { token } from "@styled-system/tokens";
-
-type ColorVariants = {
-  [K in TextColorType]: { color: string };
-};
-
-const colorVariants: ColorVariants = {
-  black: { color: "#2B4158" },
-  red: { color: "#F24150" },
-  green: { color: "#1BBF44" },
-  blue: { color: "#4285F4" },
-  yellow: { color: "#FEA642" },
-  purple: { color: "#A142FE" },
-  brown: { color: "#8B4513" },
-  white: { color: "#C1D7F4" },
-};
+import { css } from "@styled-system/css";
 
 export const optionModal = css({
   zIndex: 1000,
@@ -54,62 +35,4 @@ export const divider = css({
   width: "1px",
   height: "20px",
   margin: "0 8px",
-});
-
-export const colorOptionButton = css({
-  width: "28px",
-  height: "28px",
-  margin: "0 2px",
-  cursor: "pointer",
-  _hover: {
-    transform: "scale(1.1)",
-  },
-});
-
-// 색상 표시 원형 스타일 베이스
-const colorIndicatorBase = {
-  width: "28px",
-  height: "28px",
-  borderRadius: "3px",
-  transition: "all 0.2s",
-};
-
-// 텍스트 색상 indicator
-export const textColorIndicator = cva({
-  ...colorIndicatorBase,
-  variants: {
-    color: colorVariants,
-  },
-});
-
-export const backgroundColorIndicator = cva({
-  ...colorIndicatorBase,
-  variants: {
-    color: {
-      black: {
-        backgroundColor: `color-mix(in srgb, ${token("colors.gray.900")}, white 20%)`,
-      },
-      red: {
-        backgroundColor: `color-mix(in srgb, ${token("colors.red")}, white 20%)`,
-      },
-      yellow: {
-        backgroundColor: `color-mix(in srgb, ${token("colors.yellow")}, white 20%)`,
-      },
-      green: {
-        backgroundColor: `color-mix(in srgb, ${token("colors.green")}, white 20%)`,
-      },
-      purple: {
-        backgroundColor: `color-mix(in srgb, ${token("colors.purple")}, white 20%)`,
-      },
-      brown: {
-        backgroundColor: `color-mix(in srgb, ${token("colors.brown")}, white 20%)`,
-      },
-      blue: {
-        backgroundColor: `color-mix(in srgb, ${token("colors.blue")}, white 20%)`,
-      },
-      white: {
-        backgroundColor: token("colors.white"),
-      },
-    },
-  },
 });

--- a/client/src/features/editor/components/TextOptionModal/TextOptionModal.style.ts
+++ b/client/src/features/editor/components/TextOptionModal/TextOptionModal.style.ts
@@ -16,23 +16,34 @@ export const modalContainer = css({
 
 export const optionButton = css({
   display: "flex",
+  position: "relative",
   justifyContent: "center",
-
   alignItems: "center",
   border: "none",
   borderRadius: "4px",
-  minWidth: "28px",
+  width: "28px",
   height: "28px",
   padding: "4px 8px",
-  background: "#f5f5f5",
   cursor: "pointer",
-  "&:hover": {
-    background: "#e0e0e0",
-  },
 });
 
 export const divider = css({
   width: "1px",
   height: "20px",
   margin: "0 8px",
+});
+
+export const optionButtonText = css({
+  color: "transparent",
+  fontWeight: "bold",
+  opacity: 0.9,
+  backgroundPosition: "0% 50%",
+  backgroundClip: "text",
+  backgroundImage: "linear-gradient(45deg, #2563EB 0%, #7E22CE 50%, #FF0080 100%)",
+  backgroundSize: "200% 200%",
+  transition: "all 0.2s ease",
+  WebkitTextFillColor: "transparent",
+  _hover: {
+    backgroundPosition: "100% -10%",
+  },
 });

--- a/client/src/features/editor/components/TextOptionModal/TextOptionModal.tsx
+++ b/client/src/features/editor/components/TextOptionModal/TextOptionModal.tsx
@@ -5,7 +5,12 @@ import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { BackgroundColorOptionModal } from "../ColorOptionModal/BackgroundColorOptionModal";
 import { TextColorOptionModal } from "../ColorOptionModal/TextColorOptionModal";
-import { modalContainer, optionButton, optionModal, divider } from "./TextOptionModal.style";
+import {
+  modalContainer,
+  optionButton,
+  optionModal,
+  optionButtonText,
+} from "./TextOptionModal.style";
 
 interface SelectionModalProps {
   selectedNodes: Array<Char> | null;
@@ -239,20 +244,13 @@ export const TextOptionModal = ({
               S
             </span>
           </button>
-
-          {/** Divider: 왼쪽에 텍스트 스타일, 오른쪽에 색상 */}
-
-          <div className={divider} />
-
           {/* 텍스트 색상 버튼들 */}
           <div
-            style={{ position: "relative" }}
+            className={optionButton}
             onMouseEnter={() => handleMouseEnter("text")}
             onClick={() => handleClickButton("text")}
           >
-            <button className={optionButton}>
-              <span>A</span>
-            </button>
+            <span className={optionButtonText}>A</span>
             {hoveredType === "text" && (
               <TextColorOptionModal
                 onColorSelect={handleTextColorClick}
@@ -263,18 +261,13 @@ export const TextOptionModal = ({
               />
             )}
           </div>
-
-          <div className={divider} />
-
           {/* 배경 색상 버튼들 */}
           <div
-            style={{ position: "relative" }}
+            className={optionButton}
             onMouseEnter={() => handleMouseEnter("background")}
             onClick={() => handleClickButton("background")}
           >
-            <button className={optionButton}>
-              <span>BG</span>
-            </button>
+            <span className={optionButtonText}>BG</span>
 
             {hoveredType === "background" && (
               <BackgroundColorOptionModal

--- a/client/src/features/editor/components/TextOptionModal/TextOptionModal.tsx
+++ b/client/src/features/editor/components/TextOptionModal/TextOptionModal.tsx
@@ -1,0 +1,97 @@
+import { motion } from "framer-motion";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { modalContainer, optionButton, optionModal } from "./TextOptionModal.style";
+
+interface SelectionModalProps {
+  isOpen: boolean;
+  onBoldSelect: () => void;
+  onItalicSelect: () => void;
+  onUnderlineSelect: () => void;
+  onStrikeSelect: () => void;
+  onClose: () => void;
+}
+
+const ModalPortal = ({ children }: { children: React.ReactNode }) => {
+  return createPortal(children, document.body);
+};
+
+export const TextOptionModal = ({
+  isOpen,
+  onBoldSelect,
+  onItalicSelect,
+  onUnderlineSelect,
+  onStrikeSelect,
+  onClose,
+}: SelectionModalProps) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const [TextModalPosition, setTextModalPosition] = useState<{ top: number; left: number }>({
+    top: 0,
+    left: 0,
+  });
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const updateModalPosition = () => {
+      const selection = window.getSelection();
+      if (!selection || selection.isCollapsed) {
+        onClose();
+        return;
+      }
+
+      const range = selection.getRangeAt(0);
+      const rect = range.getBoundingClientRect();
+
+      setTextModalPosition({
+        top: rect.top - 40,
+        left: rect.left + rect.width / 2,
+      });
+    };
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+
+    updateModalPosition();
+    document.addEventListener("mousedown", handleClickOutside);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return;
+
+  return (
+    <ModalPortal>
+      {isOpen && (
+        <motion.div
+          ref={modalRef}
+          className={optionModal}
+          style={{
+            left: `${TextModalPosition.left}px`,
+            top: `${TextModalPosition.top}px`,
+          }}
+        >
+          <div className={modalContainer}>
+            <button className={optionButton} onClick={onBoldSelect}>
+              B
+            </button>
+            <button className={optionButton} onClick={onItalicSelect}>
+              I
+            </button>
+            <button className={optionButton} onClick={onUnderlineSelect}>
+              U
+            </button>
+            <button className={optionButton} onClick={onStrikeSelect}>
+              S
+            </button>
+          </div>
+        </motion.div>
+      )}
+    </ModalPortal>
+  );
+};

--- a/client/src/features/editor/components/TextOptionModal/TextOptionModal.tsx
+++ b/client/src/features/editor/components/TextOptionModal/TextOptionModal.tsx
@@ -1,9 +1,11 @@
+import { Char } from "@noctaCrdt/Node";
 import { motion } from "framer-motion";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { modalContainer, optionButton, optionModal } from "./TextOptionModal.style";
 
 interface SelectionModalProps {
+  selectedNodes: Array<Char> | null;
   isOpen: boolean;
   onBoldSelect: () => void;
   onItalicSelect: () => void;
@@ -17,6 +19,7 @@ const ModalPortal = ({ children }: { children: React.ReactNode }) => {
 };
 
 export const TextOptionModal = ({
+  selectedNodes,
   isOpen,
   onBoldSelect,
   onItalicSelect,
@@ -28,6 +31,12 @@ export const TextOptionModal = ({
   const [TextModalPosition, setTextModalPosition] = useState<{ top: number; left: number }>({
     top: 0,
     left: 0,
+  });
+  const [styleState, setStyleState] = useState({
+    isBold: false,
+    isItalic: false,
+    isUnderline: false,
+    isStrike: false,
   });
 
   useEffect(() => {
@@ -60,38 +69,141 @@ export const TextOptionModal = ({
 
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
+      setStyleState({
+        isBold: false,
+        isItalic: false,
+        isUnderline: false,
+        isStrike: false,
+      });
     };
   }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (!selectedNodes || selectedNodes.length === 0) {
+      setStyleState({
+        isBold: false,
+        isItalic: false,
+        isUnderline: false,
+        isStrike: false,
+      });
+      return;
+    }
+
+    // 각 스타일의 출현 횟수를 계산
+    const styleCounts = {
+      bold: 0,
+      italic: 0,
+      underline: 0,
+      strike: 0,
+    };
+
+    // 각 노드의 스타일을 확인하고 카운트
+    selectedNodes.forEach((node) => {
+      // node.style이 undefined인 경우 빈 배열로 처리
+      const nodeStyles = Array.isArray(node.style) ? node.style : node.style ? [node.style] : [];
+
+      if (nodeStyles.includes("bold")) styleCounts.bold += 1;
+      if (nodeStyles.includes("italic")) styleCounts.italic += 1;
+      if (nodeStyles.includes("underline")) styleCounts.underline += 1;
+      if (nodeStyles.includes("strike")) styleCounts.strike += 1;
+    });
+
+    const totalNodes = selectedNodes.length;
+
+    // 모든 노드가 해당 스타일을 가지고 있는 경우에만 true
+    setStyleState({
+      isBold: styleCounts.bold === totalNodes,
+      isItalic: styleCounts.italic === totalNodes,
+      isUnderline: styleCounts.underline === totalNodes,
+      isStrike: styleCounts.strike === totalNodes,
+    });
+  }, [selectedNodes]);
 
   if (!isOpen) return;
 
   return (
     <ModalPortal>
-      {isOpen && (
-        <motion.div
-          ref={modalRef}
-          className={optionModal}
-          style={{
-            left: `${TextModalPosition.left}px`,
-            top: `${TextModalPosition.top}px`,
-          }}
-        >
-          <div className={modalContainer}>
-            <button className={optionButton} onClick={onBoldSelect}>
+      <motion.div
+        ref={modalRef}
+        className={optionModal}
+        style={{
+          left: `${TextModalPosition.left}px`,
+          top: `${TextModalPosition.top}px`,
+        }}
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: 10 }}
+      >
+        <div className={modalContainer}>
+          <button
+            className={optionButton}
+            onClick={onBoldSelect}
+            style={{
+              backgroundColor: styleState.isBold ? "#e2e8f0" : "transparent",
+            }}
+          >
+            <span
+              style={{
+                fontWeight: "bold",
+                opacity: styleState.isBold ? 1 : 0.6,
+              }}
+            >
               B
-            </button>
-            <button className={optionButton} onClick={onItalicSelect}>
+            </span>
+          </button>
+          <button
+            className={optionButton}
+            onClick={onItalicSelect}
+            style={{
+              backgroundColor: styleState.isItalic ? "#e2e8f0" : "transparent",
+            }}
+          >
+            <span
+              style={{
+                fontStyle: "italic",
+                fontWeight: "bold",
+                opacity: styleState.isItalic ? 1 : 0.6,
+              }}
+            >
               I
-            </button>
-            <button className={optionButton} onClick={onUnderlineSelect}>
+            </span>
+          </button>
+          <button
+            className={optionButton}
+            onClick={onUnderlineSelect}
+            style={{
+              backgroundColor: styleState.isUnderline ? "#e2e8f0" : "transparent",
+            }}
+          >
+            <span
+              style={{
+                textDecoration: "underline",
+                fontWeight: "bold",
+                opacity: styleState.isUnderline ? 1 : 0.6,
+              }}
+            >
               U
-            </button>
-            <button className={optionButton} onClick={onStrikeSelect}>
+            </span>
+          </button>
+          <button
+            className={optionButton}
+            onClick={onStrikeSelect}
+            style={{
+              backgroundColor: styleState.isStrike ? "#e2e8f0" : "transparent",
+            }}
+          >
+            <span
+              style={{
+                textDecoration: "line-through",
+                fontWeight: "bold",
+                opacity: styleState.isStrike ? 1 : 0.6,
+              }}
+            >
               S
-            </button>
-          </div>
-        </motion.div>
-      )}
+            </span>
+          </button>
+        </div>
+      </motion.div>
     </ModalPortal>
   );
 };

--- a/client/src/features/editor/components/TextOptionModal/TextOptionModal.tsx
+++ b/client/src/features/editor/components/TextOptionModal/TextOptionModal.tsx
@@ -5,27 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { BackgroundColorOptionModal } from "../ColorOptionModal/BackgroundColorOptionModal";
 import { TextColorOptionModal } from "../ColorOptionModal/TextColorOptionModal";
-import {
-  modalContainer,
-  optionButton,
-  optionModal,
-  divider,
-  textColorIndicator,
-  backgroundColorIndicator,
-  colorOptionButton,
-} from "./TextOptionModal.style";
-
-// 사용 가능한 색상 배열
-const COLORS: TextColorType[] = [
-  "black",
-  "red",
-  "green",
-  "blue",
-  "yellow",
-  "purple",
-  "brown",
-  "white",
-];
+import { modalContainer, optionButton, optionModal, divider } from "./TextOptionModal.style";
 
 interface SelectionModalProps {
   selectedNodes: Array<Char> | null;
@@ -268,7 +248,7 @@ export const TextOptionModal = ({
           <div
             style={{ position: "relative" }}
             onMouseEnter={() => handleMouseEnter("text")}
-            onClick={(e) => handleClickButton("text")}
+            onClick={() => handleClickButton("text")}
           >
             <button className={optionButton}>
               <span>A</span>

--- a/client/src/features/editor/components/TextOptionModal/TextOptionModal.tsx
+++ b/client/src/features/editor/components/TextOptionModal/TextOptionModal.tsx
@@ -1,8 +1,31 @@
+import { TextColorType, BackgroundColorType } from "@noctaCrdt/Interfaces";
 import { Char } from "@noctaCrdt/Node";
 import { motion } from "framer-motion";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { modalContainer, optionButton, optionModal } from "./TextOptionModal.style";
+import { BackgroundColorOptionModal } from "../ColorOptionModal/BackgroundColorOptionModal";
+import { TextColorOptionModal } from "../ColorOptionModal/TextColorOptionModal";
+import {
+  modalContainer,
+  optionButton,
+  optionModal,
+  divider,
+  textColorIndicator,
+  backgroundColorIndicator,
+  colorOptionButton,
+} from "./TextOptionModal.style";
+
+// 사용 가능한 색상 배열
+const COLORS: TextColorType[] = [
+  "black",
+  "red",
+  "green",
+  "blue",
+  "yellow",
+  "purple",
+  "brown",
+  "white",
+];
 
 interface SelectionModalProps {
   selectedNodes: Array<Char> | null;
@@ -12,6 +35,8 @@ interface SelectionModalProps {
   onUnderlineSelect: () => void;
   onStrikeSelect: () => void;
   onClose: () => void;
+  onTextColorSelect: (color: TextColorType) => void;
+  onTextBackgroundColorSelect: (color: BackgroundColorType) => void;
 }
 
 const ModalPortal = ({ children }: { children: React.ReactNode }) => {
@@ -26,18 +51,39 @@ export const TextOptionModal = ({
   onUnderlineSelect,
   onStrikeSelect,
   onClose,
+  onTextColorSelect,
+  onTextBackgroundColorSelect,
 }: SelectionModalProps) => {
   const modalRef = useRef<HTMLDivElement>(null);
   const [TextModalPosition, setTextModalPosition] = useState<{ top: number; left: number }>({
     top: 0,
     left: 0,
   });
+  const [hoveredType, setHoveredType] = useState<"text" | "background" | null>(null);
   const [styleState, setStyleState] = useState({
     isBold: false,
     isItalic: false,
     isUnderline: false,
     isStrike: false,
   });
+
+  const handleMouseEnter = (type: "text" | "background") => {
+    setHoveredType(type);
+  };
+
+  const handleClickButton = (type: "text" | "background") => {
+    if (hoveredType === type) {
+      setHoveredType(null);
+    } else {
+      setHoveredType(type);
+    }
+  };
+
+  const handleModalClick = () => {
+    if (hoveredType !== null) {
+      setHoveredType(null);
+    }
+  };
 
   useEffect(() => {
     if (!isOpen) return;
@@ -75,6 +121,7 @@ export const TextOptionModal = ({
         isUnderline: false,
         isStrike: false,
       });
+      setHoveredType(null);
     };
   }, [isOpen, onClose]);
 
@@ -119,6 +166,16 @@ export const TextOptionModal = ({
     });
   }, [selectedNodes]);
 
+  const handleTextColorClick = (color: TextColorType) => {
+    if (!selectedNodes || selectedNodes.length === 0) return;
+    onTextColorSelect(color);
+  };
+
+  const handleTextBackgroundSelect = (color: BackgroundColorType) => {
+    if (!selectedNodes || selectedNodes.length === 0) return;
+    onTextBackgroundColorSelect(color);
+  };
+
   if (!isOpen) return;
 
   return (
@@ -128,13 +185,13 @@ export const TextOptionModal = ({
         className={optionModal}
         style={{
           left: `${TextModalPosition.left}px`,
-          top: `${TextModalPosition.top}px`,
+          top: `${TextModalPosition.top - 8}px`,
         }}
         initial={{ opacity: 0, y: 10 }}
         animate={{ opacity: 1, y: 0 }}
         exit={{ opacity: 0, y: 10 }}
       >
-        <div className={modalContainer}>
+        <div className={modalContainer} onClick={handleModalClick}>
           <button
             className={optionButton}
             onClick={onBoldSelect}
@@ -202,6 +259,53 @@ export const TextOptionModal = ({
               S
             </span>
           </button>
+
+          {/** Divider: 왼쪽에 텍스트 스타일, 오른쪽에 색상 */}
+
+          <div className={divider} />
+
+          {/* 텍스트 색상 버튼들 */}
+          <div
+            style={{ position: "relative" }}
+            onMouseEnter={() => handleMouseEnter("text")}
+            onClick={(e) => handleClickButton("text")}
+          >
+            <button className={optionButton}>
+              <span>A</span>
+            </button>
+            {hoveredType === "text" && (
+              <TextColorOptionModal
+                onColorSelect={handleTextColorClick}
+                position={{
+                  top: 40,
+                  left: 0,
+                }}
+              />
+            )}
+          </div>
+
+          <div className={divider} />
+
+          {/* 배경 색상 버튼들 */}
+          <div
+            style={{ position: "relative" }}
+            onMouseEnter={() => handleMouseEnter("background")}
+            onClick={() => handleClickButton("background")}
+          >
+            <button className={optionButton}>
+              <span>BG</span>
+            </button>
+
+            {hoveredType === "background" && (
+              <BackgroundColorOptionModal
+                onColorSelect={handleTextBackgroundSelect}
+                position={{
+                  top: 40,
+                  left: -53,
+                }}
+              />
+            )}
+          </div>
         </div>
       </motion.div>
     </ModalPortal>

--- a/client/src/features/editor/components/block/Block.style.ts
+++ b/client/src/features/editor/components/block/Block.style.ts
@@ -39,6 +39,7 @@ export const contentWrapperStyle = cva({
     flex: 1,
     flexDirection: "row",
     alignItems: "center",
+    width: "100%",
   },
 });
 
@@ -54,7 +55,7 @@ const baseTextStyle = {
   padding: "spacing.sm",
   color: "gray.900",
   backgroundColor: "transparent",
-  display: "flex",
+  display: "inline",
   alignItems: "center",
 };
 

--- a/client/src/features/editor/components/block/Block.style.ts
+++ b/client/src/features/editor/components/block/Block.style.ts
@@ -68,28 +68,28 @@ export const textContainerStyle = cva({
     type: {
       p: {
         textStyle: "display-medium16",
-        fontWeight: "bold",
+        fontWeight: "normal",
         "&:empty::before": {
           content: '"텍스트를 입력하세요..."',
         },
       },
       h1: {
         textStyle: "display-medium24",
-        fontWeight: "bold",
+        fontWeight: "normal",
         "&:empty::before": {
           content: '"제목 1"',
         },
       },
       h2: {
         textStyle: "display-medium20",
-        fontWeight: "bold",
+        fontWeight: "normal",
         "&:empty::before": {
           content: '"제목 2"',
         },
       },
       h3: {
         textStyle: "display-medium16",
-        fontWeight: "bold",
+        fontWeight: "normal",
         "&:empty::before": {
           content: '"제목 3"',
         },

--- a/client/src/features/editor/components/block/Block.tsx
+++ b/client/src/features/editor/components/block/Block.tsx
@@ -28,6 +28,7 @@ interface BlockProps {
   onInput: (e: React.FormEvent<HTMLDivElement>, block: CRDTBlock) => void;
   onCompositionEnd: (e: React.CompositionEvent<HTMLDivElement>, block: CRDTBlock) => void;
   onKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
+  onPaste: (e: React.ClipboardEvent<HTMLDivElement>, block: CRDTBlock) => void;
   onClick: (blockId: BlockId, e: React.MouseEvent<HTMLDivElement>) => void;
   onAnimationSelect: (blockId: BlockId, animation: AnimationType) => void;
   onTypeSelect: (blockId: BlockId, type: ElementType) => void;
@@ -53,6 +54,7 @@ export const Block: React.FC<BlockProps> = memo(
     onInput,
     onCompositionEnd,
     onKeyDown,
+    onPaste,
     onClick,
     onAnimationSelect,
     onTypeSelect,
@@ -241,6 +243,7 @@ export const Block: React.FC<BlockProps> = memo(
             onKeyDown={onKeyDown}
             onInput={handleInput}
             onClick={(e) => onClick(block.id, e)}
+            onPaste={(e) => onPaste(e, block)}
             onMouseUp={handleMouseUp}
             onCompositionEnd={(e) => onCompositionEnd(e, block)}
             contentEditable

--- a/client/src/features/editor/components/block/Block.tsx
+++ b/client/src/features/editor/components/block/Block.tsx
@@ -21,7 +21,7 @@ interface BlockProps {
   isActive: boolean;
   onInput: (e: React.FormEvent<HTMLDivElement>, block: CRDTBlock) => void;
   onKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
-  onClick: (blockId: BlockId) => void;
+  onClick: (blockId: BlockId, e: React.MouseEvent<HTMLDivElement>) => void;
   onAnimationSelect: (blockId: BlockId, animation: AnimationType) => void;
   onTypeSelect: (blockId: BlockId, type: ElementType) => void;
   onCopySelect: (blockId: BlockId) => void;
@@ -47,7 +47,6 @@ export const Block: React.FC<BlockProps> = memo(
     onTextStyleUpdate,
   }: BlockProps) => {
     const blockRef = useRef<HTMLDivElement>(null);
-    const blockCRDTRef = useRef<CRDTBlock>(block);
     const { isOpen, openModal, closeModal } = useModal();
     const [selectedNodes, setSelectedNodes] = useState<Array<Char> | null>(null);
     const { isAnimationStart } = useBlockAnimation(blockRef);
@@ -60,6 +59,13 @@ export const Block: React.FC<BlockProps> = memo(
     });
 
     const handleInput = (e: React.FormEvent<HTMLDivElement>) => {
+      // 텍스트를 삭제하면 <br> 태그가 생김
+      // 이를 방지하기 위해 <br> 태그 찾아서 모두 삭제
+      const brElements = e.currentTarget.getElementsByTagName("br");
+      if (brElements.length > 0) {
+        e.preventDefault();
+        Array.from(brElements).forEach((br) => br.remove());
+      }
       onInput(e, block);
     };
 
@@ -140,7 +146,7 @@ export const Block: React.FC<BlockProps> = memo(
       if (blockRef.current) {
         setInnerHTML({ element: blockRef.current, block });
       }
-    }, [block.crdt.serialize(), isActive]);
+    }, [block.crdt.serialize()]);
 
     return (
       // TODO: eslint 규칙을 수정해야 할까?
@@ -174,7 +180,7 @@ export const Block: React.FC<BlockProps> = memo(
             ref={blockRef}
             onKeyDown={onKeyDown}
             onInput={handleInput}
-            onClick={() => onClick(block.id)}
+            onClick={(e) => onClick(block.id, e)}
             onMouseUp={handleMouseUp}
             contentEditable
             spellCheck={false}

--- a/client/src/features/editor/components/block/Block.tsx
+++ b/client/src/features/editor/components/block/Block.tsx
@@ -27,7 +27,11 @@ interface BlockProps {
   isActive: boolean;
   onInput: (e: React.FormEvent<HTMLDivElement>, block: CRDTBlock) => void;
   onCompositionEnd: (e: React.CompositionEvent<HTMLDivElement>, block: CRDTBlock) => void;
-  onKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
+  onKeyDown: (
+    e: React.KeyboardEvent<HTMLDivElement>,
+    blockRef: HTMLDivElement | null,
+    block: CRDTBlock,
+  ) => void;
   onCopy: (
     e: React.ClipboardEvent<HTMLDivElement>,
     blockRef: HTMLDivElement | null,
@@ -228,7 +232,7 @@ export const Block: React.FC<BlockProps> = memo(
           <IconBlock type={block.type} index={1} />
           <div
             ref={blockRef}
-            onKeyDown={onKeyDown}
+            onKeyDown={(e) => onKeyDown(e, blockRef.current, block)}
             onInput={handleInput}
             onClick={(e) => onClick(block.id, e)}
             onCopy={(e) => onCopy(e, blockRef.current, block)}

--- a/client/src/features/editor/components/block/Block.tsx
+++ b/client/src/features/editor/components/block/Block.tsx
@@ -6,7 +6,7 @@ import { BlockId } from "@noctaCrdt/NodeId";
 import { motion } from "framer-motion";
 import { memo, useEffect, useRef, useState } from "react";
 import { useModal } from "@src/components/modal/useModal";
-import { setCaretPosition, getAbsoluteCaretPosition } from "@src/utils/caretUtils";
+import { getAbsoluteCaretPosition } from "@src/utils/caretUtils";
 import { useBlockAnimation } from "../../hooks/useBlockAnimtaion";
 import { setInnerHTML } from "../../utils/domSyncUtils";
 import { IconBlock } from "../IconBlock/IconBlock";

--- a/client/src/features/editor/components/block/Block.tsx
+++ b/client/src/features/editor/components/block/Block.tsx
@@ -217,6 +217,7 @@ export const Block: React.FC<BlockProps> = memo(
           />
         </motion.div>
         <TextOptionModal
+          selectedNodes={selectedNodes}
           isOpen={isOpen}
           onClose={closeModal}
           onBoldSelect={() => handleStyleSelect("bold")}

--- a/client/src/features/editor/components/block/Block.tsx
+++ b/client/src/features/editor/components/block/Block.tsx
@@ -59,6 +59,7 @@ export const Block: React.FC<BlockProps> = memo(
     });
 
     const handleInput = (e: React.FormEvent<HTMLDivElement>) => {
+      const currentElement = e.currentTarget;
       // 텍스트를 삭제하면 <br> 태그가 생김
       // 이를 방지하기 위해 <br> 태그 찾아서 모두 삭제
       const brElements = e.currentTarget.getElementsByTagName("br");
@@ -66,6 +67,26 @@ export const Block: React.FC<BlockProps> = memo(
         e.preventDefault();
         Array.from(brElements).forEach((br) => br.remove());
       }
+
+      // 빈 span 태그 제거
+      const cleanEmptySpans = (element: HTMLElement) => {
+        const spans = element.getElementsByTagName("span");
+        Array.from(spans).forEach((span) => {
+          // 텍스트 컨텐츠가 없거나 공백만 있는 경우
+          // 텍스트 컨텐츠가 없거나 공백만 있는 경우
+          if (!span.textContent || span.textContent.trim() === "") {
+            if (span.parentNode) {
+              console.log("빈 span 태그 제거");
+              span.parentNode.removeChild(span);
+            }
+          }
+        });
+      };
+
+      cleanEmptySpans(currentElement);
+
+      const caretPosition = getAbsoluteCaretPosition(e.currentTarget);
+      block.crdt.currentCaret = caretPosition;
       onInput(e, block);
     };
 
@@ -127,6 +148,7 @@ export const Block: React.FC<BlockProps> = memo(
         setSelectedNodes(nodes);
         openModal();
       }
+      block.crdt.currentCaret = endOffset;
     };
 
     const handleStyleSelect = (styleType: TextStyleType) => {
@@ -144,6 +166,7 @@ export const Block: React.FC<BlockProps> = memo(
 
     useEffect(() => {
       if (blockRef.current) {
+        console.log("setInnerHTML");
         setInnerHTML({ element: blockRef.current, block });
       }
     }, [block.crdt.serialize()]);

--- a/client/src/features/editor/components/block/Block.tsx
+++ b/client/src/features/editor/components/block/Block.tsx
@@ -169,11 +169,10 @@ export const Block: React.FC<BlockProps> = memo(
 
     const handleStyleSelect = (styleType: TextStyleType) => {
       if (blockRef.current && selectedNodes) {
-        const selection = window.getSelection();
         // CRDT 상태 업데이트 및 서버 전송
         onTextStyleUpdate(styleType, block.id, selectedNodes);
 
-        const position = selection?.focusOffset || 0;
+        const position = getAbsoluteCaretPosition(blockRef.current);
         block.crdt.currentCaret = position;
 
         closeModal();
@@ -182,10 +181,9 @@ export const Block: React.FC<BlockProps> = memo(
 
     const handleTextColorSelect = (color: TextColorType) => {
       if (blockRef.current && selectedNodes) {
-        const selection = window.getSelection();
         onTextColorUpdate(color, block.id, selectedNodes);
 
-        const position = selection?.focusOffset || 0;
+        const position = getAbsoluteCaretPosition(blockRef.current);
         block.crdt.currentCaret = position;
 
         closeModal();
@@ -194,10 +192,9 @@ export const Block: React.FC<BlockProps> = memo(
 
     const handleTextBackgroundColorSelect = (color: BackgroundColorType) => {
       if (blockRef.current && selectedNodes) {
-        const selection = window.getSelection();
         onTextBackgroundColorUpdate(color, block.id, selectedNodes);
 
-        const position = selection?.focusOffset || 0;
+        const position = getAbsoluteCaretPosition(blockRef.current);
         block.crdt.currentCaret = position;
 
         closeModal();

--- a/client/src/features/editor/components/block/Block.tsx
+++ b/client/src/features/editor/components/block/Block.tsx
@@ -1,6 +1,12 @@
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { AnimationType, ElementType, TextStyleType } from "@noctaCrdt/Interfaces";
+import {
+  AnimationType,
+  ElementType,
+  TextColorType,
+  TextStyleType,
+  BackgroundColorType,
+} from "@noctaCrdt/Interfaces";
 import { Block as CRDTBlock, Char } from "@noctaCrdt/Node";
 import { BlockId } from "@noctaCrdt/NodeId";
 import { motion } from "framer-motion";
@@ -32,6 +38,12 @@ interface BlockProps {
     blockId: BlockId,
     nodes: Array<Char> | null,
   ) => void;
+  onTextColorUpdate: (color: TextColorType, blockId: BlockId, nodes: Array<Char>) => void;
+  onTextBackgroundColorUpdate: (
+    color: BackgroundColorType,
+    blockId: BlockId,
+    nodes: Array<Char>,
+  ) => void;
 }
 export const Block: React.FC<BlockProps> = memo(
   ({
@@ -47,6 +59,8 @@ export const Block: React.FC<BlockProps> = memo(
     onCopySelect,
     onDeleteSelect,
     onTextStyleUpdate,
+    onTextColorUpdate,
+    onTextBackgroundColorUpdate,
   }: BlockProps) => {
     const blockRef = useRef<HTMLDivElement>(null);
     const { isOpen, openModal, closeModal } = useModal();
@@ -166,6 +180,30 @@ export const Block: React.FC<BlockProps> = memo(
       }
     };
 
+    const handleTextColorSelect = (color: TextColorType) => {
+      if (blockRef.current && selectedNodes) {
+        const selection = window.getSelection();
+        onTextColorUpdate(color, block.id, selectedNodes);
+
+        const position = selection?.focusOffset || 0;
+        block.crdt.currentCaret = position;
+
+        closeModal();
+      }
+    };
+
+    const handleTextBackgroundColorSelect = (color: BackgroundColorType) => {
+      if (blockRef.current && selectedNodes) {
+        const selection = window.getSelection();
+        onTextBackgroundColorUpdate(color, block.id, selectedNodes);
+
+        const position = selection?.focusOffset || 0;
+        block.crdt.currentCaret = position;
+
+        closeModal();
+      }
+    };
+
     useEffect(() => {
       if (blockRef.current) {
         console.log("setInnerHTML");
@@ -224,6 +262,8 @@ export const Block: React.FC<BlockProps> = memo(
           onItalicSelect={() => handleStyleSelect("italic")}
           onUnderlineSelect={() => handleStyleSelect("underline")}
           onStrikeSelect={() => handleStyleSelect("strikethrough")}
+          onTextColorSelect={handleTextColorSelect}
+          onTextBackgroundColorSelect={handleTextBackgroundColorSelect}
         />
       </motion.div>
     );

--- a/client/src/features/editor/hooks/useBlockOption.ts
+++ b/client/src/features/editor/hooks/useBlockOption.ts
@@ -102,6 +102,9 @@ export const useBlockOptionSelect = ({
         operation.node.id,
         pageId,
       );
+      insertOperation.node.style = char.style;
+      insertOperation.node.color = char.color;
+      insertOperation.node.backgroundColor = char.backgroundColor;
       sendCharInsertOperation(insertOperation);
     });
 

--- a/client/src/features/editor/hooks/useBlockOption.ts
+++ b/client/src/features/editor/hooks/useBlockOption.ts
@@ -118,6 +118,12 @@ export const useBlockOptionSelect = ({
     });
   };
 
+  const findBlock = (linkedList: BlockLinkedList, index: number) => {
+    if (index < 0) return null;
+    if (index >= linkedList.spread().length) return null;
+    return linkedList.findByIndex(index);
+  };
+
   const handleDeleteSelect = (blockId: BlockId) => {
     const currentIndex = editorCRDT.LinkedList.spread().findIndex((block) =>
       block.id.equals(blockId),
@@ -127,8 +133,9 @@ export const useBlockOptionSelect = ({
     // 삭제할 블록이 현재 활성화된 블록인 경우
     if (editorCRDT.currentBlock?.id.equals(blockId)) {
       // 다음 블록이나 이전 블록으로 currentBlock 설정
-      const nextBlock = editorCRDT.LinkedList.findByIndex(currentIndex + 1);
-      const prevBlock = editorCRDT.LinkedList.findByIndex(currentIndex - 1);
+      // 서윤님 피드백 반영
+      const nextBlock = findBlock(editorCRDT.LinkedList, currentIndex); // ✅ 이미 삭제한 후라, next는 currentIndex
+      const prevBlock = findBlock(editorCRDT.LinkedList, currentIndex - 1); // ✅ 이미 삭제한 후라, prev는 currentIndex - 1
       editorCRDT.currentBlock = nextBlock || prevBlock || null;
     }
 

--- a/client/src/features/editor/hooks/useMarkdownGrammer.ts
+++ b/client/src/features/editor/hooks/useMarkdownGrammer.ts
@@ -117,6 +117,8 @@ export const useMarkdownGrammer = ({
                   operation.node.id,
                   pageId,
                   currentCharNode.style,
+                  currentCharNode.color,
+                  currentCharNode.backgroundColor,
                 ),
               );
             });
@@ -199,6 +201,8 @@ export const useMarkdownGrammer = ({
                       prevBlock.id,
                       pageId,
                       currentCharNode.style,
+                      currentCharNode.color,
+                      currentCharNode.backgroundColor,
                     ),
                   );
                 }

--- a/client/src/features/editor/hooks/useMarkdownGrammer.ts
+++ b/client/src/features/editor/hooks/useMarkdownGrammer.ts
@@ -7,11 +7,10 @@ import {
   RemoteCharDeleteOperation,
 } from "@noctaCrdt/Interfaces";
 import { BlockLinkedList } from "@noctaCrdt/LinkedList";
-import { BlockId } from "@noctaCrdt/NodeId";
 import { useCallback } from "react";
 import { EditorStateProps } from "@features/editor/Editor";
 import { checkMarkdownPattern } from "@src/features/editor/utils/markdownPatterns";
-import { setCaretPosition } from "@src/utils/caretUtils";
+import { setCaretPosition, getAbsoluteCaretPosition } from "@src/utils/caretUtils";
 
 interface useMarkdownGrammerProps {
   editorCRDT: EditorCRDT;
@@ -50,13 +49,7 @@ export const useMarkdownGrammer = ({
         return operation;
       };
 
-      const updateEditorState = (newBlockId: BlockId | null = null) => {
-        if (
-          newBlockId !== null &&
-          editorCRDT.currentBlock !== editorCRDT.LinkedList.getNode(newBlockId)
-        ) {
-          editorCRDT.currentBlock = editorCRDT.LinkedList.getNode(newBlockId);
-        }
+      const updateEditorState = () => {
         setEditorState({
           clock: editorCRDT.clock,
           linkedList: editorCRDT.LinkedList,
@@ -74,6 +67,279 @@ export const useMarkdownGrammer = ({
       );
 
       switch (e.key) {
+        case "Enter": {
+          e.preventDefault();
+          const caretPosition = getAbsoluteCaretPosition(e.currentTarget);
+          const currentContent = currentBlock.crdt.read();
+
+          if (!currentContent && currentBlock.type !== "p") {
+            currentBlock.type = "p";
+            sendBlockUpdateOperation(editorCRDT.localUpdate(currentBlock, pageId));
+            editorCRDT.currentBlock = currentBlock;
+            editorCRDT.currentBlock.crdt.currentCaret = 0;
+            updateEditorState();
+            break;
+          }
+
+          if (!currentContent && currentBlock.type === "p") {
+            // 새로운 기본 블록 생성
+            const operation = createNewBlock(currentIndex + 1);
+            operation.node.indent = currentBlock.indent;
+            operation.node.crdt = new BlockCRDT(editorCRDT.client);
+
+            sendBlockInsertOperation({ node: operation.node, pageId });
+            editorCRDT.currentBlock = operation.node;
+            editorCRDT.currentBlock.crdt.currentCaret = 0;
+            updateEditorState();
+            break;
+          }
+
+          // 현재 캐럿 위치를 기준으로 내용 분할
+          const afterContent = currentContent.slice(caretPosition);
+
+          // 새 블록 생성
+          const operation = createNewBlock(currentIndex + 1);
+          operation.node.crdt = new BlockCRDT(editorCRDT.client);
+          operation.node.indent = currentBlock.indent;
+          sendBlockInsertOperation({ node: operation.node, pageId });
+
+          // 캐럿 이후의 텍스트 있으면 새 블록에 추가
+          if (afterContent) {
+            afterContent.split("").forEach((char, i) => {
+              sendCharInsertOperation(
+                operation.node.crdt.localInsert(i, char, operation.node.id, pageId),
+              );
+            });
+            for (let i = currentContent.length - 1; i >= caretPosition; i--) {
+              sendCharDeleteOperation(currentBlock.crdt.localDelete(i, currentBlock.id, pageId));
+            }
+          }
+
+          // 현재 블록이 li나 checkbox면 동일한 타입으로 생성
+          if (["ul", "ol", "checkbox"].includes(currentBlock.type)) {
+            operation.node.type = currentBlock.type;
+            sendBlockUpdateOperation(editorCRDT.localUpdate(operation.node, pageId));
+          }
+
+          editorCRDT.currentBlock = operation.node;
+          editorCRDT.currentBlock.crdt.currentCaret = 0;
+          updateEditorState();
+          break;
+        }
+
+        case "Backspace": {
+          const currentContent = currentBlock.crdt.read();
+          if (currentContent === "") {
+            e.preventDefault();
+            if (currentBlock.indent > 0) {
+              currentBlock.indent -= 1;
+              sendBlockUpdateOperation(editorCRDT.localUpdate(currentBlock, pageId));
+              editorCRDT.currentBlock = currentBlock;
+              updateEditorState();
+              break;
+            }
+
+            if (currentBlock.type !== "p") {
+              // 마지막 블록이면 기본 블록으로 변경
+              currentBlock.type = "p";
+              sendBlockUpdateOperation(editorCRDT.localUpdate(currentBlock, pageId));
+              editorCRDT.currentBlock = currentBlock;
+              updateEditorState();
+              break;
+            }
+
+            const prevBlock =
+              currentIndex > 0 ? editorCRDT.LinkedList.findByIndex(currentIndex - 1) : null;
+            if (prevBlock) {
+              sendBlockDeleteOperation(editorCRDT.localDelete(currentIndex, undefined, pageId));
+              prevBlock.crdt.currentCaret = prevBlock.crdt.spread().length;
+              editorCRDT.currentBlock = prevBlock;
+              updateEditorState();
+            }
+            break;
+          } else {
+            const currentCaretPosition = currentBlock.crdt.currentCaret;
+            if (currentCaretPosition === 0) {
+              if (currentBlock.indent > 0) {
+                currentBlock.indent -= 1;
+                sendBlockUpdateOperation(editorCRDT.localUpdate(currentBlock, pageId));
+                editorCRDT.currentBlock = currentBlock;
+                updateEditorState();
+                break;
+              }
+              if (currentBlock.type !== "p") {
+                currentBlock.type = "p";
+                sendBlockUpdateOperation(editorCRDT.localUpdate(currentBlock, pageId));
+                editorCRDT.currentBlock = currentBlock;
+                updateEditorState();
+                break;
+              }
+              // FIX: 서윤님 피드백 반영
+              const prevBlock =
+                currentIndex > 0 ? editorCRDT.LinkedList.findByIndex(currentIndex - 1) : null;
+              if (prevBlock) {
+                const prevBlockEndCaret = prevBlock.crdt.spread().length;
+                currentContent.split("").forEach((char) => {
+                  sendCharInsertOperation(
+                    prevBlock.crdt.localInsert(
+                      prevBlock.crdt.read().length,
+                      char,
+                      prevBlock.id,
+                      pageId,
+                    ),
+                  );
+                  sendCharDeleteOperation(
+                    currentBlock.crdt.localDelete(0, currentBlock.id, pageId),
+                  );
+                });
+                editorCRDT.currentBlock = prevBlock;
+                editorCRDT.currentBlock.crdt.currentCaret = prevBlockEndCaret;
+                sendBlockDeleteOperation(editorCRDT.localDelete(currentIndex, undefined, pageId));
+                updateEditorState();
+                e.preventDefault();
+              }
+            }
+            break;
+          }
+        }
+
+        case "Tab": {
+          e.preventDefault();
+
+          if (currentBlock) {
+            if (e.shiftKey) {
+              // shift + tab: 들여쓰기 감소
+              if (currentBlock.indent > 0) {
+                currentBlock.indent -= 1;
+                sendBlockUpdateOperation(editorCRDT.localUpdate(currentBlock, pageId));
+                editorCRDT.currentBlock = currentBlock;
+                updateEditorState();
+              }
+            } else {
+              // tab: 들여쓰기 증가
+              const maxIndent = 3;
+              if (currentBlock.indent < maxIndent) {
+                currentBlock.indent += 1;
+                sendBlockUpdateOperation(editorCRDT.localUpdate(currentBlock, pageId));
+                editorCRDT.currentBlock = currentBlock;
+                updateEditorState();
+              }
+            }
+          }
+          break;
+        }
+
+        case " ": {
+          // 여기 수정함
+          const selection = window.getSelection();
+          if (!selection) return;
+          const currentContent = currentBlock.crdt.read();
+          const markdownElement = checkMarkdownPattern(currentContent);
+          if (markdownElement && currentBlock.type === "p") {
+            e.preventDefault();
+            // 마크다운 패턴 매칭 시 타입 변경하고 내용 비우기
+            currentBlock.type = markdownElement.type;
+            for (let i = 0; i < markdownElement.length; i++) {
+              sendCharDeleteOperation(currentBlock.crdt.localDelete(0, currentBlock.id, pageId));
+            }
+            sendBlockUpdateOperation(editorCRDT.localUpdate(currentBlock, pageId));
+            currentBlock.crdt.currentCaret = 0;
+            editorCRDT.currentBlock = currentBlock;
+            updateEditorState();
+          }
+
+          break;
+        }
+
+        case "ArrowUp":
+        case "ArrowDown": {
+          const hasPrevBlock = currentIndex > 0;
+          const hasNextBlock = currentIndex < editorCRDT.LinkedList.spread().length - 1;
+          if (e.key === "ArrowUp" && !hasPrevBlock) {
+            e.preventDefault();
+            return;
+          }
+          if (e.key === "ArrowDown" && !hasNextBlock) {
+            e.preventDefault();
+            return;
+          }
+
+          const selection = window.getSelection();
+          const caretPosition = selection?.focusOffset || 0;
+
+          // 이동할 블록 결정
+          const targetIndex = e.key === "ArrowUp" ? currentIndex - 1 : currentIndex + 1;
+          const targetBlock = editorCRDT.LinkedList.findByIndex(targetIndex);
+          if (!targetBlock) return;
+          e.preventDefault();
+          targetBlock.crdt.currentCaret = Math.min(caretPosition, targetBlock.crdt.read().length);
+          editorCRDT.currentBlock = targetBlock;
+          setCaretPosition({
+            blockId: targetBlock.id,
+            linkedList: editorCRDT.LinkedList,
+            position: Math.min(caretPosition, targetBlock.crdt.read().length),
+          });
+          break;
+        }
+        case "ArrowLeft":
+        case "ArrowRight": {
+          const selection = window.getSelection();
+          const caretPosition = selection?.focusOffset || 0;
+          const textLength = currentBlock.crdt.read().length;
+
+          // 왼쪽 끝에서 이전 블록으로
+          if (e.key === "ArrowLeft" && caretPosition === 0 && currentIndex > 0) {
+            e.preventDefault(); // 기본 동작 방지
+            const prevBlock = editorCRDT.LinkedList.findByIndex(currentIndex - 1);
+            if (prevBlock) {
+              prevBlock.crdt.currentCaret = prevBlock.crdt.read().length;
+              editorCRDT.currentBlock = prevBlock;
+              setCaretPosition({
+                blockId: prevBlock.id,
+                linkedList: editorCRDT.LinkedList,
+                position: prevBlock.crdt.read().length,
+              });
+            }
+            break;
+            // 오른쪽 끝에서 다음 블록으로
+          } else if (
+            e.key === "ArrowRight" &&
+            caretPosition === textLength &&
+            currentIndex < editorCRDT.LinkedList.spread().length - 1
+          ) {
+            e.preventDefault(); // 기본 동작 방지
+            const nextBlock = editorState.linkedList.findByIndex(currentIndex + 1);
+            if (nextBlock) {
+              nextBlock.crdt.currentCaret = 0;
+              editorCRDT.currentBlock = nextBlock;
+              setCaretPosition({
+                blockId: nextBlock.id,
+                linkedList: editorCRDT.LinkedList,
+                position: 0,
+              });
+            }
+            break;
+            // 블록 내에서 이동하는 경우
+          } else {
+            if (e.key === "ArrowLeft") {
+              currentBlock.crdt.currentCaret -= 1;
+            } else {
+              currentBlock.crdt.currentCaret += 1;
+            }
+          }
+
+          break;
+        }
+      }
+    },
+    [editorCRDT, editorState, setEditorState, pageId],
+  );
+
+  return { handleKeyDown };
+};
+
+/*
+switch (e.key) {
         case "Enter": {
           e.preventDefault();
           const selection = window.getSelection();
@@ -338,9 +604,4 @@ export const useMarkdownGrammer = ({
           break;
         }
       }
-    },
-    [editorCRDT, editorState, setEditorState, pageId],
-  );
-
-  return { handleKeyDown };
-};
+ */

--- a/client/src/features/editor/hooks/useTextOptions.ts
+++ b/client/src/features/editor/hooks/useTextOptions.ts
@@ -1,5 +1,5 @@
 import { EditorCRDT } from "@noctaCrdt/Crdt";
-import { RemoteBlockUpdateOperation, TextStyleType } from "@noctaCrdt/Interfaces";
+import { TextStyleType } from "@noctaCrdt/Interfaces";
 import { Block, Char } from "@noctaCrdt/Node";
 import { BlockId } from "@noctaCrdt/NodeId";
 import { useCallback } from "react";

--- a/client/src/features/editor/hooks/useTextOptions.ts
+++ b/client/src/features/editor/hooks/useTextOptions.ts
@@ -1,5 +1,5 @@
 import { EditorCRDT } from "@noctaCrdt/Crdt";
-import { TextStyleType } from "@noctaCrdt/Interfaces";
+import { TextStyleType, TextColorType, BackgroundColorType } from "@noctaCrdt/Interfaces";
 import { Block, Char } from "@noctaCrdt/Node";
 import { BlockId } from "@noctaCrdt/NodeId";
 import { useCallback } from "react";
@@ -74,7 +74,71 @@ export const useTextOptionSelect = ({
     [pageId, sendCharUpdateOperation, editorCRDT],
   );
 
+  // 텍스트 색상 업데이트 함수
+  const handleTextColorUpdate = useCallback(
+    (color: TextColorType, blockId: BlockId, nodes: Array<Char> | null) => {
+      if (!nodes || nodes.length === 0) return;
+      const block = editorCRDT.LinkedList.getNode(blockId) as Block;
+      if (!block) return;
+
+      nodes.forEach((node) => {
+        const char = block.crdt.LinkedList.getNode(node.id) as Char;
+        if (!char) return;
+
+        // 색상 업데이트
+        char.color = color;
+
+        // 업데이트 및 전송
+        block.crdt.localUpdate(char, node.id, pageId);
+        sendCharUpdateOperation({
+          node: char,
+          blockId,
+          pageId,
+        });
+      });
+
+      setEditorState({
+        clock: editorCRDT.clock,
+        linkedList: editorCRDT.LinkedList,
+      });
+    },
+    [pageId, sendCharUpdateOperation, editorCRDT],
+  );
+
+  // 배경색상 업데이트 함수
+  const handleBackgroundColorUpdate = useCallback(
+    (color: BackgroundColorType, blockId: BlockId, nodes: Array<Char> | null) => {
+      if (!nodes || nodes.length === 0) return;
+      const block = editorCRDT.LinkedList.getNode(blockId) as Block;
+      if (!block) return;
+
+      nodes.forEach((node) => {
+        const char = block.crdt.LinkedList.getNode(node.id) as Char;
+        if (!char) return;
+
+        // 배경색상 업데이트
+        char.backgroundColor = color;
+
+        // 업데이트 및 전송
+        block.crdt.localUpdate(char, node.id, pageId);
+        sendCharUpdateOperation({
+          node: char,
+          blockId,
+          pageId,
+        });
+      });
+
+      setEditorState({
+        clock: editorCRDT.clock,
+        linkedList: editorCRDT.LinkedList,
+      });
+    },
+    [pageId, sendCharUpdateOperation, editorCRDT],
+  );
+
   return {
     onTextStyleUpdate: handleStyleUpdate,
+    onTextColorUpdate: handleTextColorUpdate,
+    onTextBackgroundColorUpdate: handleBackgroundColorUpdate,
   };
 };

--- a/client/src/features/editor/hooks/useTextOptions.ts
+++ b/client/src/features/editor/hooks/useTextOptions.ts
@@ -1,0 +1,76 @@
+import { EditorCRDT } from "@noctaCrdt/Crdt";
+import { RemoteBlockUpdateOperation, TextStyleType } from "@noctaCrdt/Interfaces";
+import { Block, Char } from "@noctaCrdt/Node";
+import { BlockId } from "@noctaCrdt/NodeId";
+import { useCallback } from "react";
+import { useSocketStore } from "@src/stores/useSocketStore";
+import { EditorStateProps } from "../Editor";
+
+interface UseTextOptionSelectProps {
+  editorCRDT: EditorCRDT;
+  setEditorState: React.Dispatch<React.SetStateAction<EditorStateProps>>;
+  pageId: string;
+  sendBlockUpdateOperation: (operation: RemoteBlockUpdateOperation) => void;
+}
+
+export const useTextOptionSelect = ({
+  editorCRDT,
+  setEditorState,
+  pageId,
+  sendBlockUpdateOperation,
+}: UseTextOptionSelectProps) => {
+  const { sendCharUpdateOperation } = useSocketStore();
+
+  const handleStyleUpdate = useCallback(
+    (styleType: TextStyleType, blockId: BlockId, nodes: Array<Char>) => {
+      if (!nodes) return;
+
+      nodes.forEach((node) => {
+        const block = editorCRDT.LinkedList.getNode(blockId) as Block;
+        if (!block) return;
+        const char = block.crdt.LinkedList.getNode(node.id) as Char;
+        if (!char) return;
+
+        const toggleStyle = (style: TextStyleType) => {
+          if (char.style.includes(style)) {
+            char.style = char.style.filter((s) => s !== style);
+          } else {
+            char.style.push(style);
+          }
+        };
+
+        switch (styleType) {
+          case "bold":
+            toggleStyle("bold");
+            break;
+          case "italic":
+            toggleStyle("italic");
+            break;
+          case "underline":
+            toggleStyle("underline");
+            break;
+          case "strikethrough":
+            toggleStyle("strikethrough");
+            break;
+        }
+
+        block.crdt.localUpdate(char, node.id, pageId);
+
+        sendCharUpdateOperation({
+          node: char,
+          blockId,
+          pageId,
+        });
+      });
+      setEditorState({
+        clock: editorCRDT.clock,
+        linkedList: editorCRDT.LinkedList,
+      });
+    },
+    [pageId, sendBlockUpdateOperation],
+  );
+
+  return {
+    onTextStyleUpdate: handleStyleUpdate,
+  };
+};

--- a/client/src/features/editor/hooks/useTextOptions.ts
+++ b/client/src/features/editor/hooks/useTextOptions.ts
@@ -10,64 +10,68 @@ interface UseTextOptionSelectProps {
   editorCRDT: EditorCRDT;
   setEditorState: React.Dispatch<React.SetStateAction<EditorStateProps>>;
   pageId: string;
-  sendBlockUpdateOperation: (operation: RemoteBlockUpdateOperation) => void;
 }
 
 export const useTextOptionSelect = ({
   editorCRDT,
   setEditorState,
   pageId,
-  sendBlockUpdateOperation,
 }: UseTextOptionSelectProps) => {
   const { sendCharUpdateOperation } = useSocketStore();
 
   const handleStyleUpdate = useCallback(
-    (styleType: TextStyleType, blockId: BlockId, nodes: Array<Char>) => {
-      if (!nodes) return;
+    (styleType: TextStyleType, blockId: BlockId, nodes: Array<Char> | null) => {
+      if (!nodes || nodes.length === 0) return;
+      const block = editorCRDT.LinkedList.getNode(blockId) as Block;
+      if (!block) return;
+
+      // 선택된 범위의 모든 문자들의 현재 스타일 상태 확인
+      const hasStyle = nodes.every((node) => {
+        const char = block.crdt.LinkedList.getNode(node.id) as Char;
+        return char && char.style.includes(styleType);
+      });
+
+      // 스타일을 추가할지 제거할지 결정 (토글 로직)
+      const shouldAdd = !hasStyle;
 
       nodes.forEach((node) => {
-        const block = editorCRDT.LinkedList.getNode(blockId) as Block;
-        if (!block) return;
         const char = block.crdt.LinkedList.getNode(node.id) as Char;
         if (!char) return;
 
-        const toggleStyle = (style: TextStyleType) => {
-          if (char.style.includes(style)) {
-            char.style = char.style.filter((s) => s !== style);
-          } else {
-            char.style.push(style);
-          }
-        };
+        // 현재 스타일 복사
+        const newStyles = [...char.style];
 
-        switch (styleType) {
-          case "bold":
-            toggleStyle("bold");
-            break;
-          case "italic":
-            toggleStyle("italic");
-            break;
-          case "underline":
-            toggleStyle("underline");
-            break;
-          case "strikethrough":
-            toggleStyle("strikethrough");
-            break;
+        if (shouldAdd) {
+          // 스타일이 없는 경우에만 추가
+          if (!newStyles.includes(styleType)) {
+            newStyles.push(styleType);
+          }
+        } else {
+          // 스타일이 있는 경우에만 제거
+          const styleIndex = newStyles.indexOf(styleType);
+          if (styleIndex !== -1) {
+            newStyles.splice(styleIndex, 1);
+          }
         }
 
-        block.crdt.localUpdate(char, node.id, pageId);
+        // 새로운 스타일 배열 할당
+        char.style = newStyles;
 
+        // 업데이트 및 전송
+        block.crdt.localUpdate(char, node.id, pageId);
         sendCharUpdateOperation({
           node: char,
           blockId,
           pageId,
         });
       });
+
       setEditorState({
         clock: editorCRDT.clock,
         linkedList: editorCRDT.LinkedList,
       });
     },
-    [pageId, sendBlockUpdateOperation],
+    [pageId, sendCharUpdateOperation, editorCRDT],
   );
 
   return {

--- a/client/src/features/editor/utils/domSyncUtils.ts
+++ b/client/src/features/editor/utils/domSyncUtils.ts
@@ -23,7 +23,7 @@ export const setInnerHTML = ({ element, block }: SetInnerHTMLProps): void => {
   }
 
   // 각 위치별 모든 적용된 스타일을 추적
-  const positionStyles: Set<string>[] = chars.map((char, index) => {
+  const positionStyles: Set<string>[] = chars.map((_, index) => {
     const styleSet = new Set<string>();
 
     // 해당 위치에 적용되어야 하는 모든 스타일 수집
@@ -91,6 +91,7 @@ const setsEqual = (a: Set<string>, b: Set<string>): boolean => {
 
 const sanitizeText = (text: string): string => {
   return text
+    .replace(/<br>/g, "&nbsp;")
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")

--- a/client/src/features/editor/utils/domSyncUtils.ts
+++ b/client/src/features/editor/utils/domSyncUtils.ts
@@ -129,96 +129,6 @@ export const setInnerHTML = ({ element, block }: SetInnerHTMLProps): void => {
   }
 };
 
-/*
-const getClassNames = (styles: Set<string>): string => {
-  // underline과 strikethrough가 함께 있는 경우 특별 처리
-  if (styles.has("underline") && styles.has("strikethrough")) {
-    return css({
-      textDecoration: "underline line-through",
-      fontWeight: styles.has("bold") ? "bold" : "normal",
-      fontStyle: styles.has("italic") ? "italic" : "normal",
-    });
-  }
-
-  // 일반적인 경우
-  return css({
-    textDecoration: styles.has("underline")
-      ? "underline"
-      : styles.has("strikethrough")
-        ? "line-through"
-        : "none",
-    // textStyle 속성 대신 직접 스타일 지정
-    fontWeight: styles.has("bold") ? "bold" : "normal",
-    fontStyle: styles.has("italic") ? "italic" : "normal",
-  });
-};
-*/
-
-/*
-export const setInnerHTML = ({ element, block }: SetInnerHTMLProps): void => {
-  const chars = block.crdt.LinkedList.spread();
-  if (chars.length === 0) {
-    element.innerHTML = "";
-    return;
-  }
-
-  // 각 위치별 모든 적용된 스타일을 추적
-  const positionStyles: Set<string>[] = chars.map((_, index) => {
-    const styleSet = new Set<string>();
-
-    // 해당 위치에 적용되어야 하는 모든 스타일 수집
-    chars.forEach((c, i) => {
-      if (i === index) {
-        c.style.forEach((style) => styleSet.add(TEXT_STYLES[style]));
-      }
-    });
-
-    return styleSet;
-  });
-
-  let html = "";
-  let currentStyles = new Set<string>();
-  let spanOpen = false;
-
-  chars.forEach((char, index) => {
-    const targetStyles = positionStyles[index];
-
-    // 스타일이 변경되었는지 확인
-    const styleChanged = !setsEqual(currentStyles, targetStyles);
-
-    // 스타일이 변경되었으면 현재 span 태그 닫기
-    if (styleChanged && spanOpen) {
-      html += "</span>";
-      spanOpen = false;
-    }
-
-    // 새로운 스타일 조합으로 span 태그 열기
-    if (styleChanged && targetStyles.size > 0) {
-      const className = getClassNames(targetStyles);
-      html += `<span class="${className}">`;
-      spanOpen = true;
-    }
-
-    // 텍스트 추가
-    html += sanitizeText(char.value);
-
-    // 다음 문자로 넘어가기 전에 현재 스타일 상태 업데이트
-    currentStyles = targetStyles;
-
-    // 마지막 문자이고 span이 열려있으면 닫기
-    if (index === chars.length - 1 && spanOpen) {
-      html += "</span>";
-      spanOpen = false;
-    }
-  });
-
-  // DOM 업데이트
-  if (element.innerHTML !== html) {
-    element.innerHTML = html;
-  }
-};
-*/
-
 // Set 비교 헬퍼 함수
 const setsEqual = (a: Set<string>, b: Set<string>): boolean => {
   if (a.size !== b.size) return false;
@@ -242,4 +152,25 @@ const sanitizeText = (text: string): string => {
 export const arraysEqual = (a: string[], b: string[]): boolean => {
   if (a.length !== b.length) return false;
   return a.sort().every((val, idx) => val === b.sort()[idx]);
+};
+
+export const getTextOffset = (
+  blockRef: HTMLDivElement,
+  container: Node,
+  offset: number,
+): number => {
+  let totalOffset = 0;
+  const walker = document.createTreeWalker(blockRef, NodeFilter.SHOW_TEXT, null);
+
+  let node = walker.nextNode();
+  while (node) {
+    if (node === container) {
+      return totalOffset + offset;
+    }
+    if (node.compareDocumentPosition(container) & Node.DOCUMENT_POSITION_FOLLOWING) {
+      totalOffset += node.textContent?.length || 0;
+    }
+    node = walker.nextNode();
+  }
+  return totalOffset;
 };

--- a/client/src/features/editor/utils/domSyncUtils.ts
+++ b/client/src/features/editor/utils/domSyncUtils.ts
@@ -1,0 +1,105 @@
+import { Block } from "@noctaCrdt/Node";
+
+interface SetInnerHTMLProps {
+  element: HTMLDivElement;
+  block: Block;
+}
+
+const getHtmlTag = (style: string): string => {
+  const tagMappings: Record<string, string> = {
+    bold: "b", // bold는 <b>
+    italic: "i", // italic은 <i>
+    underline: "u", // underline은 <u>
+    strikethrough: "s", // strikethrough는 <s>
+  };
+  return tagMappings[style] || "span"; // 기본은 <span>
+};
+
+export const setInnerHTML = ({ element, block }: SetInnerHTMLProps): void => {
+  const chars = block.crdt.LinkedList.spread();
+  if (chars.length === 0) {
+    element.innerHTML = "";
+    return;
+  }
+
+  // 각 위치별 모든 적용된 스타일을 추적
+  const positionStyles: Set<string>[] = chars.map((char, index) => {
+    const styleSet = new Set<string>();
+
+    // 해당 위치에 적용되어야 하는 모든 스타일 수집
+    chars.forEach((c, i) => {
+      if (i === index) {
+        c.style.forEach((style) => styleSet.add(style));
+      }
+    });
+
+    return styleSet;
+  });
+
+  let html = "";
+  let currentStyles = new Set<string>();
+
+  chars.forEach((char, index) => {
+    const targetStyles = positionStyles[index];
+
+    // 제거해야 할 스타일 (현재는 있지만 다음에는 필요 없는 스타일)
+    const stylesToRemove = [...currentStyles].filter((style) => !targetStyles.has(style));
+
+    // 추가해야 할 스타일 (현재는 없지만 다음에는 필요한 스타일)
+    const stylesToAdd = [...targetStyles].filter((style) => !currentStyles.has(style));
+
+    // 제거할 스타일 태그 닫기 (역순으로)
+    stylesToRemove.reverse().forEach((style) => {
+      html += `</${getHtmlTag(style)}>`;
+    });
+
+    // 새로운 스타일 태그 열기
+    stylesToAdd.forEach((style) => {
+      html += `<${getHtmlTag(style)}>`;
+    });
+
+    // 텍스트 추가
+    html += sanitizeText(char.value);
+
+    // 다음 문자로 넘어가기 전에 현재 스타일 상태 업데이트
+    currentStyles = new Set(targetStyles);
+
+    // 마지막 문자이거나 다음 문자와 스타일이 다른 경우
+    if (index === chars.length - 1 || !setsEqual(targetStyles, positionStyles[index + 1])) {
+      // 현재 열려있는 모든 태그 닫기
+      [...currentStyles].reverse().forEach((style) => {
+        html += `</${getHtmlTag(style)}>`;
+      });
+      currentStyles.clear();
+    }
+  });
+
+  // DOM 업데이트
+  if (element.innerHTML !== html) {
+    element.innerHTML = html;
+  }
+};
+
+// Set 비교 헬퍼 함수
+const setsEqual = (a: Set<string>, b: Set<string>): boolean => {
+  if (a.size !== b.size) return false;
+  for (const item of a) {
+    if (!b.has(item)) return false;
+  }
+  return true;
+};
+
+const sanitizeText = (text: string): string => {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+};
+
+// 배열 비교 헬퍼 함수
+export const arraysEqual = (a: string[], b: string[]): boolean => {
+  if (a.length !== b.length) return false;
+  return a.sort().every((val, idx) => val === b.sort()[idx]);
+};

--- a/client/src/features/editor/utils/domSyncUtils.ts
+++ b/client/src/features/editor/utils/domSyncUtils.ts
@@ -1,4 +1,6 @@
+import { TextColorType, BackgroundColorType } from "@noctaCrdt/Interfaces";
 import { Block } from "@noctaCrdt/Node";
+import { COLOR } from "@src/constants/color";
 import { css } from "styled-system/css";
 
 export const TEXT_STYLES: Record<string, string> = {
@@ -13,6 +15,121 @@ interface SetInnerHTMLProps {
   block: Block;
 }
 
+interface TextStyleState {
+  styles: Set<string>;
+  color: TextColorType;
+  backgroundColor: BackgroundColorType;
+}
+
+const textColorMap: Record<TextColorType, string> = {
+  black: COLOR.GRAY_900,
+  red: COLOR.RED,
+  green: COLOR.GREEN,
+  blue: COLOR.BLUE,
+  yellow: COLOR.YELLOW,
+  purple: COLOR.PURPLE,
+  brown: COLOR.BROWN,
+  white: COLOR.WHITE,
+};
+
+const getClassNames = (state: TextStyleState): string => {
+  // underline과 strikethrough가 함께 있는 경우 특별 처리
+  const baseStyles = {
+    textDecoration:
+      state.styles.has("underline") && state.styles.has("strikethrough")
+        ? "underline line-through"
+        : state.styles.has("underline")
+          ? "underline"
+          : state.styles.has("strikethrough")
+            ? "line-through"
+            : "none",
+    fontWeight: state.styles.has("bold") ? "bold" : "normal",
+    fontStyle: state.styles.has("italic") ? "italic" : "normal",
+    color: textColorMap[state.color],
+  };
+
+  // backgroundColor가 transparent가 아닐 때만 추가
+  if (state.backgroundColor !== "transparent") {
+    return css({
+      ...baseStyles,
+      backgroundColor: textColorMap[state.backgroundColor],
+    });
+  }
+
+  return css(baseStyles);
+};
+
+export const setInnerHTML = ({ element, block }: SetInnerHTMLProps): void => {
+  const chars = block.crdt.LinkedList.spread();
+  if (chars.length === 0) {
+    element.innerHTML = "";
+    return;
+  }
+
+  // 각 위치별 모든 적용된 스타일을 추적
+  const positionStyles: TextStyleState[] = chars.map((char) => {
+    const styleSet = new Set<string>();
+
+    // 현재 문자의 스타일 수집
+    char.style.forEach((style) => styleSet.add(TEXT_STYLES[style]));
+
+    return {
+      styles: styleSet,
+      color: char.color,
+      backgroundColor: char.backgroundColor,
+    };
+  });
+
+  let html = "";
+  let currentState: TextStyleState = {
+    styles: new Set<string>(),
+    color: "black",
+    backgroundColor: "transparent",
+  };
+  let spanOpen = false;
+
+  chars.forEach((char, index) => {
+    const targetState = positionStyles[index];
+
+    // 스타일, 색상, 배경색 변경 확인
+    const styleChanged =
+      !setsEqual(currentState.styles, targetState.styles) ||
+      currentState.color !== targetState.color ||
+      currentState.backgroundColor !== targetState.backgroundColor;
+
+    // 변경되었으면 현재 span 태그 닫기
+    if (styleChanged && spanOpen) {
+      html += "</span>";
+      spanOpen = false;
+    }
+
+    // 새로운 스타일 조합으로 span 태그 열기
+    if (styleChanged) {
+      const className = getClassNames(targetState);
+      html += `<span class="${className}">`;
+      spanOpen = true;
+    }
+
+    // 텍스트 추가
+    html += sanitizeText(char.value);
+
+    // 다음 문자로 넘어가기 전에 현재 상태 업데이트
+    currentState = targetState;
+
+    // 마지막 문자이고 span이 열려있으면 닫기
+    if (index === chars.length - 1 && spanOpen) {
+      html += "</span>";
+      spanOpen = false;
+    }
+  });
+
+  // DOM 업데이트
+  if (element.innerHTML !== html) {
+    element.innerHTML = html;
+  }
+};
+
+/*
 const getClassNames = (styles: Set<string>): string => {
   // underline과 strikethrough가 함께 있는 경우 특별 처리
   if (styles.has("underline") && styles.has("strikethrough")) {
@@ -35,7 +152,9 @@ const getClassNames = (styles: Set<string>): string => {
     fontStyle: styles.has("italic") ? "italic" : "normal",
   });
 };
+*/
 
+/*
 export const setInnerHTML = ({ element, block }: SetInnerHTMLProps): void => {
   const chars = block.crdt.LinkedList.spread();
   if (chars.length === 0) {
@@ -98,6 +217,7 @@ export const setInnerHTML = ({ element, block }: SetInnerHTMLProps): void => {
     element.innerHTML = html;
   }
 };
+*/
 
 // Set 비교 헬퍼 함수
 const setsEqual = (a: Set<string>, b: Set<string>): boolean => {

--- a/client/src/stores/useSocketStore.ts
+++ b/client/src/stores/useSocketStore.ts
@@ -121,14 +121,11 @@ export const useSocketStore = create<SocketStore>((set, get) => ({
 
   sendBlockInsertOperation: (operation: RemoteBlockInsertOperation) => {
     const { socket } = get();
-    console.log("block insert operation", operation);
-    console.log("socket", socket);
     socket?.emit("insert/block", operation);
   },
 
   sendCharInsertOperation: (operation: RemoteCharInsertOperation) => {
     const { socket } = get();
-    console.log("char insert operation", operation);
     socket?.emit("insert/char", operation);
   },
 

--- a/client/src/stores/useSocketStore.ts
+++ b/client/src/stores/useSocketStore.ts
@@ -6,6 +6,7 @@ import {
   RemoteCharDeleteOperation,
   RemoteBlockUpdateOperation,
   RemoteBlockReorderOperation,
+  RemoteCharUpdateOperation,
   CursorPosition,
   WorkSpaceSerializedProps,
 } from "@noctaCrdt/Interfaces";
@@ -25,6 +26,7 @@ interface SocketStore {
   sendCharInsertOperation: (operation: RemoteCharInsertOperation) => void;
   sendBlockDeleteOperation: (operation: RemoteBlockDeleteOperation) => void;
   sendCharDeleteOperation: (operation: RemoteCharDeleteOperation) => void;
+  sendCharUpdateOperation: (operation: RemoteCharUpdateOperation) => void;
   sendBlockReorderOperation: (operation: RemoteBlockReorderOperation) => void;
   sendCursorPosition: (position: CursorPosition) => void;
   subscribeToRemoteOperations: (handlers: RemoteOperationHandlers) => (() => void) | undefined;
@@ -39,6 +41,7 @@ interface RemoteOperationHandlers {
   onRemoteBlockReorder: (operation: RemoteBlockReorderOperation) => void;
   onRemoteCharInsert: (operation: RemoteCharInsertOperation) => void;
   onRemoteCharDelete: (operation: RemoteCharDeleteOperation) => void;
+  onRemoteCharUpdate: (operation: RemoteCharUpdateOperation) => void;
   onRemoteCursor: (position: CursorPosition) => void;
 }
 
@@ -144,6 +147,11 @@ export const useSocketStore = create<SocketStore>((set, get) => ({
     socket?.emit("delete/char", operation);
   },
 
+  sendCharUpdateOperation: (operation: RemoteCharUpdateOperation) => {
+    const { socket } = get();
+    socket?.emit("update/char", operation);
+  },
+
   sendCursorPosition: (position: CursorPosition) => {
     const { socket } = get();
     socket?.emit("cursor", position);
@@ -164,6 +172,7 @@ export const useSocketStore = create<SocketStore>((set, get) => ({
     socket.on("reorder/block", handlers.onRemoteBlockReorder);
     socket.on("insert/char", handlers.onRemoteCharInsert);
     socket.on("delete/char", handlers.onRemoteCharDelete);
+    socket.on("update/char", handlers.onRemoteCharUpdate);
     socket.on("cursor", handlers.onRemoteCursor);
 
     return () => {
@@ -173,6 +182,7 @@ export const useSocketStore = create<SocketStore>((set, get) => ({
       socket.off("reorder/block", handlers.onRemoteBlockReorder);
       socket.off("insert/char", handlers.onRemoteCharInsert);
       socket.off("delete/char", handlers.onRemoteCharDelete);
+      socket.off("update/char", handlers.onRemoteCharUpdate);
       socket.off("cursor", handlers.onRemoteCursor);
     };
   },

--- a/client/src/styles/tokens/color.ts
+++ b/client/src/styles/tokens/color.ts
@@ -23,4 +23,13 @@ export const colors = {
   green: {
     value: COLOR.GREEN,
   },
+  purple: {
+    value: COLOR.PURPLE,
+  },
+  brown: {
+    value: COLOR.BROWN,
+  },
+  blue: {
+    value: COLOR.BLUE,
+  },
 };

--- a/client/src/styles/typography.ts
+++ b/client/src/styles/typography.ts
@@ -60,4 +60,30 @@ export const textStyles = defineTextStyles({
       textTransform: "None",
     },
   },
+
+  bold: {
+    value: {
+      fontWeight: "bold",
+    },
+  },
+  italic: {
+    value: {
+      fontStyle: "italic",
+    },
+  },
+  underline: {
+    value: {
+      textDecoration: "underline",
+    },
+  },
+  strikethrough: {
+    value: {
+      textDecoration: "line-through",
+    },
+  },
+  "underline-strikethrough": {
+    value: {
+      textDecoration: "underline line-through",
+    },
+  },
 });

--- a/client/src/utils/caretUtils.ts
+++ b/client/src/utils/caretUtils.ts
@@ -7,6 +7,68 @@ interface SetCaretPositionProps {
   position?: number; // 특정 위치로 캐럿을 설정하고 싶을 때 사용
 }
 
+export const getAbsoluteCaretPosition = (element: HTMLElement): number => {
+  const selection = window.getSelection();
+  if (!selection?.focusNode) return 0;
+
+  // 실제 텍스트 내용만 추출하여 위치를 계산하는 함수
+  const collectTextNodes = (root: Node): Text[] => {
+    const nodes: Text[] = [];
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+      acceptNode: (node) => {
+        // 실제 텍스트 노드만 수집
+        if (node.nodeType === Node.TEXT_NODE && node.textContent) {
+          return NodeFilter.FILTER_ACCEPT;
+        }
+        return NodeFilter.FILTER_SKIP;
+      },
+    });
+
+    let node: Node | null;
+    while ((node = walker.nextNode())) {
+      nodes.push(node as Text);
+    }
+    return nodes;
+  };
+
+  // 모든 텍스트 노드 수집
+  const textNodes = collectTextNodes(element);
+
+  // focusNode가 텍스트 노드인 경우
+  if (selection.focusNode.nodeType === Node.TEXT_NODE) {
+    let position = 0;
+
+    for (const node of textNodes) {
+      if (node === selection.focusNode) {
+        return position + selection.focusOffset;
+      }
+      position += node.textContent?.length || 0;
+    }
+  }
+
+  // focusNode가 element인 경우
+  if (selection.focusNode === element) {
+    return selection.focusOffset;
+  }
+
+  // focusNode가 span인 경우
+  if (selection.focusNode.nodeType === Node.ELEMENT_NODE) {
+    let position = 0;
+    const focusElement = selection.focusNode;
+
+    for (const node of textNodes) {
+      if (focusElement.contains(node)) {
+        if (position + (node.textContent?.length || 0) >= selection.focusOffset) {
+          return position + selection.focusOffset;
+        }
+        position += node.textContent?.length || 0;
+      }
+    }
+  }
+
+  return 0;
+};
+
 export const setCaretPosition = ({
   blockId,
   linkedList,
@@ -29,30 +91,42 @@ export const setCaretPosition = ({
 
     editableDiv.focus();
 
-    const range = document.createRange();
-    const textNodes = Array.from(editableDiv.childNodes).filter(
-      (node) => node.nodeType === Node.TEXT_NODE,
-    );
-
     let currentPosition = 0;
     let targetNode: Node | null = null;
     let targetOffset = 0;
 
-    for (const node of textNodes) {
-      const textContent = node.textContent || "";
-      if (currentPosition + textContent.length >= position) {
+    const walker = document.createTreeWalker(editableDiv, NodeFilter.SHOW_TEXT, {
+      acceptNode: (node): number => {
+        return node.nodeType === Node.TEXT_NODE && node.textContent !== "\n"
+          ? NodeFilter.FILTER_ACCEPT
+          : NodeFilter.FILTER_SKIP;
+      },
+    });
+
+    let node: Node | null;
+    while ((node = walker.nextNode())) {
+      const length = node.textContent?.length || 0;
+      if (currentPosition + length >= position) {
         targetNode = node;
         targetOffset = position - currentPosition;
         break;
       }
-      currentPosition += textContent.length;
+      currentPosition += length;
     }
 
     if (!targetNode) {
-      targetNode = editableDiv;
-      targetOffset = editableDiv.childNodes.length;
+      // 마지막 텍스트 노드 찾기
+      const textNodes = Array.from(editableDiv.querySelectorAll("*"))
+        .flatMap((element) => Array.from(element.childNodes))
+        .filter((node): node is Text => node.nodeType === Node.TEXT_NODE);
+
+      const lastTextNode = textNodes.length > 0 ? textNodes[textNodes.length - 1] : editableDiv;
+
+      targetNode = lastTextNode;
+      targetOffset = lastTextNode.textContent?.length || 0;
     }
 
+    const range = document.createRange();
     range.setStart(targetNode, targetOffset);
     range.collapse(true);
 
@@ -60,151 +134,5 @@ export const setCaretPosition = ({
     selection.addRange(range);
   } catch (error) {
     console.error("Error setting caret position:", error);
-    return;
   }
-};
-
-/*
-export const getAbsoluteCaretPosition = (element: HTMLElement): number => {
-  const selection = window.getSelection();
-  if (!selection?.focusNode) return 0;
-
-  // 스타일 태그 내부의 텍스트 노드도 포함하여 모든 텍스트 노드 수집
-  const collectTextNodesAndOffsets = (root: Node): { node: Text; offset: number }[] => {
-    const nodes: { node: Text; offset: number }[] = [];
-    let currentOffset = 0;
-
-    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null);
-    let node = walker.nextNode();
-
-    while (node) {
-      if (node.nodeType === Node.TEXT_NODE && node.nodeValue !== "\n") {
-        nodes.push({
-          node: node as Text,
-          offset: currentOffset,
-        });
-        currentOffset += node.nodeValue?.length || 0;
-      }
-      node = walker.nextNode();
-    }
-
-    return nodes;
-  };
-
-  const textNodesWithOffsets = collectTextNodesAndOffsets(element);
-
-  // focusNode가 텍스트 노드인 경우
-  if (selection.focusNode.nodeType === Node.TEXT_NODE) {
-    const focusTextNode = selection.focusNode as Text;
-    const nodeInfo = textNodesWithOffsets.find((info) => info.node === focusTextNode);
-    if (nodeInfo) {
-      return nodeInfo.offset + selection.focusOffset;
-    }
-  }
-
-  // focusNode가 element인 경우 (모든 텍스트가 삭제된 경우)
-  if (selection.focusNode === element) {
-    if (textNodesWithOffsets.length === 0) {
-      return 0;
-    }
-    // 마지막 텍스트 노드의 끝 위치 반환
-    const lastNode = textNodesWithOffsets[textNodesWithOffsets.length - 1];
-    return lastNode.offset + lastNode.node.length;
-  }
-
-  return 0;
-};
-*/
-
-export const getAbsoluteCaretPosition = (element: HTMLElement): number => {
-  const selection = window.getSelection();
-  if (!selection?.focusNode) return 0;
-
-  const collectTextNodesAndOffsets = (
-    root: Node,
-  ): {
-    node: Text | Node;
-    offset: number;
-    length: number;
-  }[] => {
-    const nodes: { node: Text | Node; offset: number; length: number }[] = [];
-    let currentOffset = 0;
-
-    // 모든 노드를 순회하면서 텍스트 노드와 그 부모 노드의 정보 수집
-    const walker = document.createTreeWalker(
-      root,
-      NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT,
-      null,
-    );
-
-    let node = walker.nextNode();
-    while (node) {
-      if (node.nodeType === Node.TEXT_NODE && node.nodeValue !== "\n") {
-        nodes.push({
-          node,
-          offset: currentOffset,
-          length: node.nodeValue?.length || 0,
-        });
-        currentOffset += node.nodeValue?.length || 0;
-      } else if (node.nodeType === Node.ELEMENT_NODE) {
-        // 요소 노드도 추적
-        nodes.push({
-          node,
-          offset: currentOffset,
-          length: node.textContent?.length || 0,
-        });
-      }
-      node = walker.nextNode();
-    }
-
-    return nodes;
-  };
-
-  const textNodesWithOffsets = collectTextNodesAndOffsets(element);
-  // focusNode가 텍스트 노드인 경우
-  if (selection.focusNode.nodeType === Node.TEXT_NODE) {
-    const focusTextNode = selection.focusNode;
-    const nodeInfo = textNodesWithOffsets.find((info) => info.node === focusTextNode);
-    if (nodeInfo) {
-      return nodeInfo.offset + selection.focusOffset;
-    }
-  }
-
-  // focusNode가 요소 노드인 경우 (스타일 태그 등)
-  if (selection.focusNode.nodeType === Node.ELEMENT_NODE) {
-    const focusElement = selection.focusNode;
-
-    // 현재 요소의 모든 이전 텍스트 길이 계산
-    let totalOffset = 0;
-    for (const nodeInfo of textNodesWithOffsets) {
-      if (nodeInfo.node === focusElement || focusElement.contains(nodeInfo.node)) {
-        if (nodeInfo.node === focusElement) {
-          return totalOffset + selection.focusOffset;
-        }
-        // focusOffset이 요소 내부의 특정 위치를 가리키는 경우
-        if (
-          selection.focusOffset > 0 &&
-          nodeInfo.offset + nodeInfo.length >= selection.focusOffset
-        ) {
-          return nodeInfo.offset + selection.focusOffset;
-        }
-      }
-      totalOffset += nodeInfo.length;
-    }
-    return totalOffset;
-  }
-
-  // focusNode가 element 자체인 경우 (빈 블록이나 모든 텍스트가 삭제된 경우)
-  if (selection.focusNode === element) {
-    // 선택된 오프셋까지의 모든 텍스트 길이 합산
-    let totalOffset = 0;
-    for (const nodeInfo of textNodesWithOffsets) {
-      if (nodeInfo.offset < selection.focusOffset) {
-        totalOffset += nodeInfo.length;
-      }
-    }
-    return totalOffset;
-  }
-
-  return 0;
 };

--- a/client/src/utils/caretUtils.ts
+++ b/client/src/utils/caretUtils.ts
@@ -4,68 +4,207 @@ import { BlockId } from "@noctaCrdt/NodeId";
 interface SetCaretPositionProps {
   blockId: BlockId;
   linkedList: BlockLinkedList | TextLinkedList;
-  clientX?: number;
-  clientY?: number;
   position?: number; // 특정 위치로 캐럿을 설정하고 싶을 때 사용
 }
 
 export const setCaretPosition = ({
   blockId,
   linkedList,
-  clientX,
-  clientY,
   position,
-}: SetCaretPositionProps): boolean => {
+}: SetCaretPositionProps): void => {
   try {
+    if (position === undefined) return;
     const selection = window.getSelection();
-    if (!selection) return false;
+    if (!selection) return;
 
     const blockElements = Array.from(
       document.querySelectorAll('.d_flex.pos_relative.w_full[data-group="true"]'),
     );
     const currentIndex = linkedList.spread().findIndex((b) => b.id === blockId);
     const targetElement = blockElements[currentIndex];
-    if (!targetElement) return false;
+    if (!targetElement) return;
 
     const editableDiv = targetElement.querySelector('[contenteditable="true"]') as HTMLDivElement;
-    if (!editableDiv) return false;
+    if (!editableDiv) return;
 
     editableDiv.focus();
 
-    let range: Range;
+    const range = document.createRange();
+    const textNodes = Array.from(editableDiv.childNodes).filter(
+      (node) => node.nodeType === Node.TEXT_NODE,
+    );
 
-    if (clientX !== undefined && clientY !== undefined) {
-      // 클릭 위치에 따른 캐럿 설정
-      const clickRange = document.caretRangeFromPoint(clientX, clientY);
-      if (!clickRange) return false;
-      range = clickRange;
-    } else if (position !== undefined) {
-      // 특정 위치에 캐럿 설정
-      range = document.createRange();
-      const textNode =
-        Array.from(editableDiv.childNodes).find((node) => node.nodeType === Node.TEXT_NODE) || null;
-      if (!textNode) {
-        // 텍스트 노드가 없으면 새로운 텍스트 노드를 추가
-        const newTextNode = document.createTextNode("");
-        editableDiv.appendChild(newTextNode);
-        range.setStart(newTextNode, 0);
-      } else {
-        // position이 텍스트 길이를 초과하지 않도록 조정
-        const safePosition = Math.min(position, textNode.textContent?.length || 0);
-        range.setStart(textNode, safePosition);
+    let currentPosition = 0;
+    let targetNode: Node | null = null;
+    let targetOffset = 0;
+
+    for (const node of textNodes) {
+      const textContent = node.textContent || "";
+      if (currentPosition + textContent.length >= position) {
+        targetNode = node;
+        targetOffset = position - currentPosition;
+        break;
       }
-
-      range.collapse(true);
-    } else {
-      return false;
+      currentPosition += textContent.length;
     }
+
+    if (!targetNode) {
+      targetNode = editableDiv;
+      targetOffset = editableDiv.childNodes.length;
+    }
+
+    range.setStart(targetNode, targetOffset);
+    range.collapse(true);
 
     selection.removeAllRanges();
     selection.addRange(range);
-
-    return true;
   } catch (error) {
     console.error("Error setting caret position:", error);
-    return false;
+    return;
   }
+};
+
+/*
+export const getAbsoluteCaretPosition = (element: HTMLElement): number => {
+  const selection = window.getSelection();
+  if (!selection?.focusNode) return 0;
+
+  // 스타일 태그 내부의 텍스트 노드도 포함하여 모든 텍스트 노드 수집
+  const collectTextNodesAndOffsets = (root: Node): { node: Text; offset: number }[] => {
+    const nodes: { node: Text; offset: number }[] = [];
+    let currentOffset = 0;
+
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null);
+    let node = walker.nextNode();
+
+    while (node) {
+      if (node.nodeType === Node.TEXT_NODE && node.nodeValue !== "\n") {
+        nodes.push({
+          node: node as Text,
+          offset: currentOffset,
+        });
+        currentOffset += node.nodeValue?.length || 0;
+      }
+      node = walker.nextNode();
+    }
+
+    return nodes;
+  };
+
+  const textNodesWithOffsets = collectTextNodesAndOffsets(element);
+
+  // focusNode가 텍스트 노드인 경우
+  if (selection.focusNode.nodeType === Node.TEXT_NODE) {
+    const focusTextNode = selection.focusNode as Text;
+    const nodeInfo = textNodesWithOffsets.find((info) => info.node === focusTextNode);
+    if (nodeInfo) {
+      return nodeInfo.offset + selection.focusOffset;
+    }
+  }
+
+  // focusNode가 element인 경우 (모든 텍스트가 삭제된 경우)
+  if (selection.focusNode === element) {
+    if (textNodesWithOffsets.length === 0) {
+      return 0;
+    }
+    // 마지막 텍스트 노드의 끝 위치 반환
+    const lastNode = textNodesWithOffsets[textNodesWithOffsets.length - 1];
+    return lastNode.offset + lastNode.node.length;
+  }
+
+  return 0;
+};
+*/
+
+export const getAbsoluteCaretPosition = (element: HTMLElement): number => {
+  const selection = window.getSelection();
+  if (!selection?.focusNode) return 0;
+
+  const collectTextNodesAndOffsets = (
+    root: Node,
+  ): {
+    node: Text | Node;
+    offset: number;
+    length: number;
+  }[] => {
+    const nodes: { node: Text | Node; offset: number; length: number }[] = [];
+    let currentOffset = 0;
+
+    // 모든 노드를 순회하면서 텍스트 노드와 그 부모 노드의 정보 수집
+    const walker = document.createTreeWalker(
+      root,
+      NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT,
+      null,
+    );
+
+    let node = walker.nextNode();
+    while (node) {
+      if (node.nodeType === Node.TEXT_NODE && node.nodeValue !== "\n") {
+        nodes.push({
+          node,
+          offset: currentOffset,
+          length: node.nodeValue?.length || 0,
+        });
+        currentOffset += node.nodeValue?.length || 0;
+      } else if (node.nodeType === Node.ELEMENT_NODE) {
+        // 요소 노드도 추적
+        nodes.push({
+          node,
+          offset: currentOffset,
+          length: node.textContent?.length || 0,
+        });
+      }
+      node = walker.nextNode();
+    }
+
+    return nodes;
+  };
+
+  const textNodesWithOffsets = collectTextNodesAndOffsets(element);
+  // focusNode가 텍스트 노드인 경우
+  if (selection.focusNode.nodeType === Node.TEXT_NODE) {
+    const focusTextNode = selection.focusNode;
+    const nodeInfo = textNodesWithOffsets.find((info) => info.node === focusTextNode);
+    if (nodeInfo) {
+      return nodeInfo.offset + selection.focusOffset;
+    }
+  }
+
+  // focusNode가 요소 노드인 경우 (스타일 태그 등)
+  if (selection.focusNode.nodeType === Node.ELEMENT_NODE) {
+    const focusElement = selection.focusNode;
+
+    // 현재 요소의 모든 이전 텍스트 길이 계산
+    let totalOffset = 0;
+    for (const nodeInfo of textNodesWithOffsets) {
+      if (nodeInfo.node === focusElement || focusElement.contains(nodeInfo.node)) {
+        if (nodeInfo.node === focusElement) {
+          return totalOffset + selection.focusOffset;
+        }
+        // focusOffset이 요소 내부의 특정 위치를 가리키는 경우
+        if (
+          selection.focusOffset > 0 &&
+          nodeInfo.offset + nodeInfo.length >= selection.focusOffset
+        ) {
+          return nodeInfo.offset + selection.focusOffset;
+        }
+      }
+      totalOffset += nodeInfo.length;
+    }
+    return totalOffset;
+  }
+
+  // focusNode가 element 자체인 경우 (빈 블록이나 모든 텍스트가 삭제된 경우)
+  if (selection.focusNode === element) {
+    // 선택된 오프셋까지의 모든 텍스트 길이 합산
+    let totalOffset = 0;
+    for (const nodeInfo of textNodesWithOffsets) {
+      if (nodeInfo.offset < selection.focusOffset) {
+        totalOffset += nodeInfo.length;
+      }
+    }
+    return totalOffset;
+  }
+
+  return 0;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.3
         version: 4.3.3(vite@5.4.10(@types/node@20.17.6)(lightningcss@1.25.1)(terser@5.36.0))
+      dompurify:
+        specifier: ^3.2.1
+        version: 3.2.1
       eslint-plugin-import:
         specifier: ^2.29.1
         version: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.3.3))(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
@@ -1568,6 +1571,9 @@ packages:
   '@types/supertest@6.0.2':
     resolution: {integrity: sha512-137ypx2lk/wTQbW6An6safu9hXmajAifU/s7szAHLN/FeIm5w7yR0Wkl9fdJMRSHwOn4HLAI0DaB2TOORuhPDg==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/webidl-conversions@7.0.3':
     resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
 
@@ -2395,6 +2401,9 @@ packages:
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
+
+  dompurify@3.2.1:
+    resolution: {integrity: sha512-NBHEsc0/kzRYQd+AY6HR6B/IgsqzBABrqJbpCDQII/OK6h7B7LXzweZTDsqSW2LkTRpoxf18YUP+YjGySk6B3w==}
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
@@ -6743,6 +6752,9 @@ snapshots:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.9
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/webidl-conversions@7.0.3': {}
 
   '@types/whatwg-url@11.0.5':
@@ -7673,6 +7685,10 @@ snapshots:
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
+
+  dompurify@3.2.1:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dot-case@3.0.4:
     dependencies:

--- a/server/src/crdt/crdt.gateway.ts
+++ b/server/src/crdt/crdt.gateway.ts
@@ -275,6 +275,8 @@ export class CrdtGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
       const operation = {
         node: data.node,
         blockId: data.blockId,
+        pageId: data.pageId,
+        style: data.style || [],
       };
       client.broadcast.emit("insert/char", operation);
     } catch (error) {

--- a/server/src/crdt/crdt.gateway.ts
+++ b/server/src/crdt/crdt.gateway.ts
@@ -277,6 +277,8 @@ export class CrdtGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
         blockId: data.blockId,
         pageId: data.pageId,
         style: data.style || [],
+        color: data.color ? data.color : "black",
+        backgroundColor: data.backgroundColor ? data.backgroundColor : "transparent",
       };
       client.broadcast.emit("insert/char", operation);
     } catch (error) {

--- a/server/src/crdt/crdt.gateway.ts
+++ b/server/src/crdt/crdt.gateway.ts
@@ -18,6 +18,7 @@ import {
   RemoteBlockUpdateOperation,
   RemotePageCreateOperation,
   RemoteBlockReorderOperation,
+  RemoteCharUpdateOperation,
   CursorPosition,
 } from "@noctaCrdt/Interfaces";
 import { Logger } from "@nestjs/common";
@@ -394,6 +395,44 @@ export class CrdtGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
     } catch (error) {
       this.logger.error(
         `블록 Reorder 연산 처리 중 오류 발생 - Client ID: ${clientInfo?.clientId}`,
+        error.stack,
+      );
+      throw new WsException(`Update 연산 실패: ${error.message}`);
+    }
+  }
+
+  @SubscribeMessage("update/char")
+  async handleCharUpdate(
+    @MessageBody() data: RemoteCharUpdateOperation,
+    @ConnectedSocket() client: Socket,
+  ): Promise<void> {
+    const clientInfo = this.clientMap.get(client.id);
+    try {
+      this.logger.debug(
+        `Update 연산 수신 - Client ID: ${clientInfo?.clientId}, Data:`,
+        JSON.stringify(data),
+      );
+
+      const currentPage = this.workSpaceService
+        .getWorkspace()
+        .pageList.find((p) => p.id === data.pageId);
+      if (!currentPage) {
+        throw new Error(`Page with id ${data.pageId} not found`);
+      }
+      const currentBlock = currentPage.crdt.LinkedList.nodeMap[JSON.stringify(data.blockId)];
+      if (!currentBlock) {
+        throw new Error(`Block with id ${data.blockId} not found`);
+      }
+      currentBlock.crdt.remoteUpdate(data);
+      const operation = {
+        node: data.node,
+        blockId: data.blockId,
+        pageId: data.pageId,
+      };
+      client.broadcast.emit("update/char", operation);
+    } catch (error) {
+      this.logger.error(
+        `Char Update 연산 처리 중 오류 발생 - Client ID: ${clientInfo?.clientId}`,
         error.stack,
       );
       throw new WsException(`Update 연산 실패: ${error.message}`);


### PR DESCRIPTION
## 📝 변경 사항

- #53 

## 🔍 변경 사항 설명

복사, 붙여넣기, 한번에 삭제 모두 브라우저 기본 이벤트를 막습니다.

- 텍스트 복사: 드래그 해서 선택된 텍스트의 노드를 찾습니다. 선택된 노드들의 스타일 정보가 있으면 스타일 정보를 포함한 메타데이터를 클립보드에 저장합니다(text/plain이 아닌 객체 형식)
- 텍스트 붙여넣기
  - 일반 텍스트일 경우: text/plain에 저장되어 있는 텍스트 정보를 한글자씩 삽입 연산을 서버로 전송합니다.
  - 스타일 텍스트일 경우: 클립보드에 저장한 객체를 가지고 와서 각 노드별로 value와 스타일을 적용한 텍스트 삽입 연산을 서버에 전송합니다.
- 텍스트 한번에 삭제: 드래그 해서 선택된 텍스트의 노드를 찾습니다. 선택된 노드들을 하나씩 삭제 연산처리해서 서버로 전송합니다.

## 🙏 질문 사항

- 현재 색상 관련된 데이터가 클라이언트간에 통신이 안되고 있는 것 같습니다. 이 부분은 확인해보고 수정하겠습니다.
- 붙여넣기 할때, 특정 조건에서 캐럿이 이전 위치에 계속 있는 문제가 있는 것 같은데 어떤 조건에서 일어나는 문제인지는 아직 확인하지 못했습니다.

혹시 문제되는 부분 발견하시면 피드백 부탁드립니다!

## 📷 스크린샷 (선택)

https://github.com/user-attachments/assets/d75ac56c-4560-4aae-b1d6-787a2489d1c5


## ✅ 작성자 체크리스트

- [x] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [x] 로컬에서 모든 기능이 정상 작동함
- [x] 린터 및 포맷터로 코드 정리됨
- [x] 의존성 업데이트 확인
- [ ] 문서 업데이트 또는 주석 추가 (필요 시)
