### PR TITLE
Feature/#206 이전 텍스트 스타일 연속으로 적용

### DIFF
--- a/client/src/features/editor/Editor.tsx
+++ b/client/src/features/editor/Editor.tsx
@@ -167,12 +167,34 @@ export const Editor = ({ onTitleChange, pageId, pageTitle, serializedEditorData 
           charNode = block.crdt.localInsert(0, addedChar, block.id, pageId);
         } else if (caretPosition > currentContent.length) {
           // 맨 뒤에 삽입
+          const prevChar = editorCRDT.current.currentBlock?.crdt.LinkedList.findByIndex(
+            currentContent.length - 1,
+          );
           const addedChar = newContent[newContent.length - 1];
-          charNode = block.crdt.localInsert(currentContent.length, addedChar, block.id, pageId);
+          charNode = block.crdt.localInsert(
+            currentContent.length,
+            addedChar,
+            block.id,
+            pageId,
+            prevChar?.style,
+            prevChar?.color,
+            prevChar?.backgroundColor,
+          );
         } else {
           // 중간에 삽입
+          const prevChar = editorCRDT.current.currentBlock?.crdt.LinkedList.findByIndex(
+            validCaretPosition - 1,
+          );
           const addedChar = newContent[validCaretPosition - 1];
-          charNode = block.crdt.localInsert(validCaretPosition - 1, addedChar, block.id, pageId);
+          charNode = block.crdt.localInsert(
+            validCaretPosition - 1,
+            addedChar,
+            block.id,
+            pageId,
+            prevChar?.style,
+            prevChar?.color,
+            prevChar?.backgroundColor,
+          );
         }
         editorCRDT.current.currentBlock!.crdt.currentCaret = caretPosition;
         sendCharInsertOperation({ node: charNode.node, blockId: block.id, pageId });

--- a/client/src/features/editor/Editor.tsx
+++ b/client/src/features/editor/Editor.tsx
@@ -167,18 +167,21 @@ export const Editor = ({ onTitleChange, pageId, pageTitle, serializedEditorData 
           charNode = block.crdt.localInsert(0, addedChar, block.id, pageId);
         } else if (caretPosition > currentContent.length) {
           // 맨 뒤에 삽입
-          const prevChar = editorCRDT.current.currentBlock?.crdt.LinkedList.findByIndex(
-            currentContent.length - 1,
-          );
+          let prevChar;
+          if (currentContent.length > 0) {
+            prevChar = editorCRDT.current.currentBlock?.crdt.LinkedList.findByIndex(
+              currentContent.length - 1,
+            );
+          }
           const addedChar = newContent[newContent.length - 1];
           charNode = block.crdt.localInsert(
             currentContent.length,
             addedChar,
             block.id,
             pageId,
-            prevChar?.style,
-            prevChar?.color,
-            prevChar?.backgroundColor,
+            prevChar ? prevChar.style : [],
+            prevChar ? prevChar.color : undefined,
+            prevChar ? prevChar.backgroundColor : undefined,
           );
         } else {
           // 중간에 삽입

--- a/client/src/features/editor/components/TextOptionModal/TextOptionModal.tsx
+++ b/client/src/features/editor/components/TextOptionModal/TextOptionModal.tsx
@@ -56,18 +56,9 @@ export const TextOptionModal = ({
     setHoveredType(type);
   };
 
-  const handleClickButton = (type: "text" | "background") => {
-    if (hoveredType === type) {
-      setHoveredType(null);
-    } else {
-      setHoveredType(type);
-    }
-  };
-
-  const handleModalClick = () => {
-    if (hoveredType !== null) {
-      setHoveredType(null);
-    }
+  const handleModalClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setHoveredType(null);
   };
 
   useEffect(() => {
@@ -175,6 +166,7 @@ export const TextOptionModal = ({
         initial={{ opacity: 0, y: 10 }}
         animate={{ opacity: 1, y: 0 }}
         exit={{ opacity: 0, y: 10 }}
+        onMouseDown={handleModalClick}
       >
         <div className={modalContainer} onClick={handleModalClick}>
           <button
@@ -245,11 +237,7 @@ export const TextOptionModal = ({
             </span>
           </button>
           {/* 텍스트 색상 버튼들 */}
-          <div
-            className={optionButton}
-            onMouseEnter={() => handleMouseEnter("text")}
-            onClick={() => handleClickButton("text")}
-          >
+          <div className={optionButton} onMouseEnter={() => handleMouseEnter("text")}>
             <span className={optionButtonText}>A</span>
             {hoveredType === "text" && (
               <TextColorOptionModal
@@ -262,11 +250,7 @@ export const TextOptionModal = ({
             )}
           </div>
           {/* 배경 색상 버튼들 */}
-          <div
-            className={optionButton}
-            onMouseEnter={() => handleMouseEnter("background")}
-            onClick={() => handleClickButton("background")}
-          >
+          <div className={optionButton} onMouseEnter={() => handleMouseEnter("background")}>
             <span className={optionButtonText}>BG</span>
 
             {hoveredType === "background" && (

--- a/client/src/features/editor/components/TextOptionModal/TextOptionModal.tsx
+++ b/client/src/features/editor/components/TextOptionModal/TextOptionModal.tsx
@@ -166,9 +166,8 @@ export const TextOptionModal = ({
         initial={{ opacity: 0, y: 10 }}
         animate={{ opacity: 1, y: 0 }}
         exit={{ opacity: 0, y: 10 }}
-        onMouseDown={handleModalClick}
       >
-        <div className={modalContainer} onClick={handleModalClick}>
+        <div className={modalContainer} onClick={handleModalClick} onMouseDown={handleModalClick}>
           <button
             className={optionButton}
             onClick={onBoldSelect}
@@ -239,31 +238,30 @@ export const TextOptionModal = ({
           {/* 텍스트 색상 버튼들 */}
           <div className={optionButton} onMouseEnter={() => handleMouseEnter("text")}>
             <span className={optionButtonText}>A</span>
-            {hoveredType === "text" && (
-              <TextColorOptionModal
-                onColorSelect={handleTextColorClick}
-                position={{
-                  top: 40,
-                  left: 0,
-                }}
-              />
-            )}
           </div>
           {/* 배경 색상 버튼들 */}
           <div className={optionButton} onMouseEnter={() => handleMouseEnter("background")}>
             <span className={optionButtonText}>BG</span>
-
-            {hoveredType === "background" && (
-              <BackgroundColorOptionModal
-                onColorSelect={handleTextBackgroundSelect}
-                position={{
-                  top: 40,
-                  left: -53,
-                }}
-              />
-            )}
           </div>
         </div>
+        {hoveredType === "text" && (
+          <TextColorOptionModal
+            onColorSelect={handleTextColorClick}
+            position={{
+              top: 44,
+              left: 84,
+            }}
+          />
+        )}
+        {hoveredType === "background" && (
+          <BackgroundColorOptionModal
+            onColorSelect={handleTextBackgroundSelect}
+            position={{
+              top: 44,
+              left: 84,
+            }}
+          />
+        )}
       </motion.div>
     </ModalPortal>
   );


### PR DESCRIPTION
## 📝 변경 사항

- #206 

## 🔍 변경 사항 설명

- 텍스트 모달 UX 개선
  - 텍스트를 드래그하고 있는 상태에서 모달창 내부를 클릭할때는 포커스 사라지지 않음
  - 색상과 배경 버튼은 hover할때만 서브 모달이 나오고, 두 버튼을 클릭해도 동작하지 않도록 수정
- 텍스트 입력시, 이전 텍스트에 스타일이 적용되어 있으면 동일한 스타일로 삽입

## 🙏 질문 사항

- 평소에는 잘 작동하는데, 맥 영상 녹화를 틀면 버튼에 마우스를 올려도 포인터로 안바뀌는 문제가 있습니다. 코드 문제는 아닌 것 같은데, 이유를 잘 모르겠습니다...

## 📷 스크린샷 (선택)

https://github.com/user-attachments/assets/4d2b35f1-041c-4c2e-b99d-9eed30bdcc69

## ✅ 작성자 체크리스트

- [x] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [x] 로컬에서 모든 기능이 정상 작동함
- [x] 린터 및 포맷터로 코드 정리됨
- [ ] 의존성 업데이트 확인
- [ ] 문서 업데이트 또는 주석 추가 (필요 시)
