### PR TITLE
Feature/#39 슬래시를 입력하여 블록 생성 목록 구현

### DIFF
--- a/client/src/constants/option.ts
+++ b/client/src/constants/option.ts
@@ -13,6 +13,7 @@ export const OPTION_CATEGORIES = {
       { id: "ol", label: "순서 리스트" },
       { id: "checkbox", label: "체크박스" },
       { id: "blockquote", label: "인용문" },
+      { id: "hr", label: "구분선" },
     ] as { id: ElementType; label: string }[],
   },
   ANIMATION: {

--- a/client/src/features/editor/components/OptionModal/OptionModal.style.ts
+++ b/client/src/features/editor/components/OptionModal/OptionModal.style.ts
@@ -22,6 +22,17 @@ export const optionButton = css({
   },
 });
 
+export const optionTypeButton = css({
+  borderRadius: "8px",
+  width: "100%",
+  paddingBlock: "4px",
+  paddingInline: "8px",
+  textAlign: "left",
+  "&.selected": {
+    backgroundColor: "gray.100/40",
+  },
+});
+
 export const modalContainer = css({
   display: "flex",
   gap: "1",

--- a/client/src/features/editor/components/TypeOptionModal/TypeOptionModal.tsx
+++ b/client/src/features/editor/components/TypeOptionModal/TypeOptionModal.tsx
@@ -21,7 +21,9 @@ export const TypeOptionModal = ({
 }: TypeOptionModalProps) => {
   const modalRef = useRef<HTMLDivElement>(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const options = OPTION_CATEGORIES.TYPE.options;
+  const {
+    TYPE: { options },
+  } = OPTION_CATEGORIES;
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     switch (e.key) {

--- a/client/src/features/editor/components/TypeOptionModal/TypeOptionModal.tsx
+++ b/client/src/features/editor/components/TypeOptionModal/TypeOptionModal.tsx
@@ -1,0 +1,92 @@
+import { motion } from "framer-motion";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { OPTION_CATEGORIES } from "@src/constants/option";
+import { modalContainer, optionModal, optionTypeButton } from "../OptionModal/OptionModal.style";
+import { modal } from "../OptionModal/OptionModal.animaiton";
+import { ElementType } from "node_modules/@noctaCrdt/Interfaces";
+
+interface TypeOptionModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onTypeSelect: (type: ElementType) => void;
+  position: { top: number; left: number };
+}
+
+export const TypeOptionModal = ({
+  isOpen,
+  onClose,
+  onTypeSelect,
+  position,
+}: TypeOptionModalProps) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const options = OPTION_CATEGORIES.TYPE.options;
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    switch (e.key) {
+      case "ArrowUp":
+        e.preventDefault();
+        setSelectedIndex((prev) => (prev <= 0 ? options.length - 1 : prev - 1));
+        break;
+
+      case "ArrowDown":
+        e.preventDefault();
+        setSelectedIndex((prev) => (prev >= options.length - 1 ? 0 : prev + 1));
+        break;
+
+      case "Enter":
+        e.preventDefault();
+        onTypeSelect(options[selectedIndex].id);
+
+        onClose();
+        break;
+
+      case "Escape":
+        e.preventDefault();
+        onClose();
+        break;
+    }
+  };
+
+  useEffect(() => {
+    if (isOpen && modalRef.current) {
+      modalRef.current.focus();
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <motion.div
+      ref={modalRef}
+      tabIndex={0}
+      className={optionModal}
+      style={{
+        left: `${position.left}px`,
+        top: `${position.top}px`,
+        outline: "none",
+      }}
+      initial={modal.initial}
+      animate={modal.animate}
+      onKeyDown={handleKeyDown}
+    >
+      <div className={modalContainer}>
+        {options.map((option, index) => (
+          <button
+            key={option.id}
+            className={`${optionTypeButton} ${index === selectedIndex && "selected"}`}
+            onClick={() => {
+              onTypeSelect(option.id);
+              onClose();
+            }}
+            onMouseEnter={() => setSelectedIndex(index)}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+    </motion.div>,
+    document.body,
+  );
+};

--- a/client/src/features/editor/components/block/Block.tsx
+++ b/client/src/features/editor/components/block/Block.tsx
@@ -20,6 +20,7 @@ import { MenuBlock } from "../MenuBlock/MenuBlock";
 import { TextOptionModal } from "../TextOptionModal/TextOptionModal";
 import { blockAnimation } from "./Block.animation";
 import { textContainerStyle, blockContainerStyle, contentWrapperStyle } from "./Block.style";
+import { TypeOptionModal } from "../TypeOptionModal/TypeOptionModal";
 
 interface BlockProps {
   id: string;
@@ -86,6 +87,9 @@ export const Block: React.FC<BlockProps> = memo(
       },
     });
 
+    const [slashModalOpen, setSlashModalOpen] = useState(false);
+    const [slashModalPosition, setSlashModalPosition] = useState({ top: 0, left: 0 });
+
     const handleInput = (e: React.FormEvent<HTMLDivElement>) => {
       const currentElement = e.currentTarget;
       // 텍스트를 삭제하면 <br> 태그가 생김
@@ -115,7 +119,18 @@ export const Block: React.FC<BlockProps> = memo(
 
       const caretPosition = getAbsoluteCaretPosition(e.currentTarget);
       block.crdt.currentCaret = caretPosition;
-      onInput(e, block);
+
+      const element = e.currentTarget;
+      const newContent = element.textContent || "";
+
+      if (newContent === "/" && !slashModalOpen) {
+        const rect = e.currentTarget.getBoundingClientRect();
+        setSlashModalPosition({
+          top: rect.top,
+          left: rect.left + 0,
+        });
+        setSlashModalOpen(true);
+      }
     };
 
     const handleAnimationSelect = (animation: AnimationType) => {
@@ -257,6 +272,12 @@ export const Block: React.FC<BlockProps> = memo(
           onStrikeSelect={() => handleStyleSelect("strikethrough")}
           onTextColorSelect={handleTextColorSelect}
           onTextBackgroundColorSelect={handleTextBackgroundColorSelect}
+        />
+        <TypeOptionModal
+          isOpen={slashModalOpen}
+          onClose={() => setSlashModalOpen(false)}
+          onTypeSelect={(type) => handleTypeSelect(type)}
+          position={slashModalPosition}
         />
       </motion.div>
     );

--- a/client/src/features/editor/components/block/Block.tsx
+++ b/client/src/features/editor/components/block/Block.tsx
@@ -130,6 +130,8 @@ export const Block: React.FC<BlockProps> = memo(
           left: rect.left + 0,
         });
         setSlashModalOpen(true);
+      } else {
+        onInput(e, block);
       }
     };
 


### PR DESCRIPTION
## 📝 변경 사항

- `/` 를 입력하여 블록 생성 목록 구현

## 🔍 변경 사항 설명

- `/` 은 마크다운과 다르게 입력하자마자 `/`를 확인하고, 옵션 모달창을 띄워줘야하기에 input 핸들러에서 동작합니다.
- 또한 p태그 뿐만 아니라 h1, h2에서도 `/` 입력이 오면 옵션 모달창을 띄워주었습니다.
- 키보드 이동 (위/아래)에 따라 옵션을 선택가능하고, 엔터를 치면 저장됩니다
- 마우스 이동으로도 선택가능하며, 옵션 모달창은 esc를 누를경우/리스트 중 하나를 선택했을 경우 닫아줍니다.

## 🙏 질문 사항

- [ ] 리뷰어에게 부탁하고싶은 체크리스트를 추가합니다.

## 📷 스크린샷 (선택)


https://github.com/user-attachments/assets/f888bba7-0220-47ae-b6d9-e8dbb89fca40



## ✅ 작성자 체크리스트

- [x] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [x] 로컬에서 모든 기능이 정상 작동함
- [x] 린터 및 포맷터로 코드 정리됨
- [x] 의존성 업데이트 확인
- [ ] 문서 업데이트 또는 주석 추가 (필요 시)
