### PR TITLE
Feature/#200 ux 및 스타일 완성도 개선

### DIFF
--- a/client/src/components/sidebar/Sidebar.style.ts
+++ b/client/src/components/sidebar/Sidebar.style.ts
@@ -13,7 +13,6 @@ export const sidebarContainer = cx(
 );
 export const navWrapper = css({
   display: "flex",
-  gap: "md",
   flexDirection: "column",
   width: "100%",
   height: "calc(100% - 176px)",

--- a/client/src/components/sidebar/Sidebar.tsx
+++ b/client/src/components/sidebar/Sidebar.tsx
@@ -1,4 +1,6 @@
+import { useIsSidebarOpen, useSidebarActions } from "@stores/useSidebarStore";
 import { motion } from "framer-motion";
+import { PageIconType } from "node_modules/@noctaCrdt/Interfaces";
 import { useState } from "react";
 import { IconButton } from "@components/button/IconButton";
 import { Modal } from "@components/modal/modal";
@@ -7,7 +9,6 @@ import { MAX_VISIBLE_PAGE } from "@src/constants/page";
 import { AuthButton } from "@src/features/auth/AuthButton";
 import { useSocketStore } from "@src/stores/useSocketStore";
 import { Page } from "@src/types/page";
-import { useIsSidebarOpen, useSidebarActions } from "@stores/useSidebarStore";
 import { animation, contentVariants, sidebarVariants } from "./Sidebar.animation";
 import {
   sidebarContainer,
@@ -23,10 +24,16 @@ export const Sidebar = ({
   pages,
   handlePageAdd,
   handlePageOpen,
+  handlePageUpdate,
 }: {
   pages: Page[];
   handlePageAdd: () => void;
   handlePageOpen: ({ pageId }: { pageId: string }) => void;
+  handlePageUpdate: (
+    pageId: string,
+    updates: { title?: string; icon?: PageIconType },
+    syncWithServer: boolean,
+  ) => void;
 }) => {
   const visiblePages = pages.filter((page) => page.isVisible);
   const isMaxVisiblePage = visiblePages.length >= MAX_VISIBLE_PAGE;
@@ -100,6 +107,7 @@ export const Sidebar = ({
                 {...item}
                 onClick={() => handlePageItemClick(item.id)}
                 onDelete={() => confirmPageDelete(item)}
+                handleIconUpdate={handlePageUpdate}
               />
             </motion.div>
           ))

--- a/client/src/components/sidebar/components/pageItem/PageItem.tsx
+++ b/client/src/components/sidebar/components/pageItem/PageItem.tsx
@@ -12,9 +12,21 @@ interface PageItemProps {
   icon: PageIconType;
   onClick: () => void;
   onDelete?: (id: string) => void; // 추가: 삭제 핸들러
+  handleIconUpdate: (
+    pageId: string,
+    updates: { title?: string; icon?: PageIconType },
+    syncWithServer: boolean,
+  ) => void;
 }
 
-export const PageItem = ({ id, icon, title, onClick, onDelete }: PageItemProps) => {
+export const PageItem = ({
+  id,
+  icon,
+  title,
+  onClick,
+  onDelete,
+  handleIconUpdate,
+}: PageItemProps) => {
   const { isOpen, openModal, closeModal } = useModal();
   const [pageIcon, setPageIcon] = useState<PageIconType>(icon);
   // 삭제 버튼 클릭 핸들러
@@ -39,6 +51,7 @@ export const PageItem = ({ id, icon, title, onClick, onDelete }: PageItemProps) 
   const handleSelectIcon = (e: React.MouseEvent, type: PageIconType) => {
     e.stopPropagation();
     setPageIcon(type);
+    handleIconUpdate(id, { icon: type }, true);
     closeModal();
   };
 

--- a/client/src/features/editor/Editor.tsx
+++ b/client/src/features/editor/Editor.tsx
@@ -362,6 +362,11 @@ export const Editor = ({ onTitleChange, pageId, pageTitle, serializedEditorData 
 
   useEffect(() => {
     if (!editorCRDT || !editorCRDT.current.currentBlock) return;
+
+    const { activeElement } = document;
+    if (activeElement?.tagName.toLowerCase() === "input") {
+      return; // input에 포커스가 있으면 캐럿 위치 변경하지 않음
+    }
     setCaretPosition({
       blockId: editorCRDT.current.currentBlock.id,
       linkedList: editorCRDT.current.LinkedList,

--- a/client/src/features/editor/components/block/Block.style.ts
+++ b/client/src/features/editor/components/block/Block.style.ts
@@ -74,7 +74,7 @@ export const textContainerStyle = cva({
       p: {
         textStyle: "display-medium16",
         fontWeight: "normal",
-        "&:empty::before": {
+        "&:empty:focus::before": {
           content: '"텍스트를 입력하세요..."',
         },
       },

--- a/client/src/features/workSpace/WorkSpace.tsx
+++ b/client/src/features/workSpace/WorkSpace.tsx
@@ -58,7 +58,12 @@ export const WorkSpace = () => {
           opacity: isInitialized && !isLoading ? 1 : 0,
         })}
       >
-        <Sidebar pages={pages} handlePageAdd={fetchPage} handlePageOpen={openPage} />
+        <Sidebar
+          pages={pages}
+          handlePageAdd={fetchPage}
+          handlePageOpen={openPage}
+          handlePageUpdate={updatePage}
+        />
         <div className={content}>
           {visiblePages.map((page) =>
             page.isLoaded ? (

--- a/client/src/features/workSpace/hooks/usePagesManage.ts
+++ b/client/src/features/workSpace/hooks/usePagesManage.ts
@@ -172,6 +172,13 @@ export const usePagesManage = (workspace: WorkSpace | null, clientId: number | n
             : { ...p, isActive: false },
         ),
       );
+      // setTimeout을 사용하여 다음 렌더링 사이클에서 포커스
+      setTimeout(() => {
+        const titleInput = document.querySelector(`#${pageId} input`);
+        if (titleInput instanceof HTMLInputElement) {
+          titleInput.focus();
+        }
+      }, 0);
     }
   };
   const closePage = (pageId: string) => {


### PR DESCRIPTION
- #200 

## 📝 변경 사항

- 아이콘 상태도 서버 인스턴스에 저장하기


- 사이드바 페이지 아이템 간격 수정


- openPage 실행시, userCaret을 해당 페이지에 속하게 수정 (현재는 1번페이지로 다 이동함)


- editor 내부의 글자가 caret이 위치할때만 placeHolder를 보이게 수정 (노션처럼)


## 🔍 변경 사항 설명

- 아이콘 상태도 서버 인스턴스에 저장하기
  - pageUpdate를 활용하여 적용

- 사이드바 페이지 아이템 간격 수정
  - gap을 0px로 수정

- openPage 실행시, userCaret을 해당 페이지에 속하게 수정 (현재는 1번페이지로 다 이동함)
  - 선택할때, pageId에 input박스로 태그를 위치시킴.

- editor 내부의 글자가 caret이 위치할때만 placeHolder를 보이게 수정 (노션처럼)


## 🙏 질문 사항

- [ ] 리뷰어에게 부탁하고싶은 체크리스트를 추가합니다.

## 📷 스크린샷 (선택)

- UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

## ✅ 작성자 체크리스트

- [ ] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [ ] 로컬에서 모든 기능이 정상 작동함
- [ ] 린터 및 포맷터로 코드 정리됨
- [ ] 의존성 업데이트 확인
- [ ] 문서 업데이트 또는 주석 추가 (필요 시)
