### PR TITLE
Feature/#011 순서있는 리스트 숫자 구현

### DIFF
--- a/@noctaCrdt/Crdt.ts
+++ b/@noctaCrdt/Crdt.ts
@@ -114,7 +114,7 @@ export class EditorCRDT extends CRDT<Block> {
     updatedBlock.indent = block.indent;
     updatedBlock.style = block.style;
     updatedBlock.type = block.type;
-    // this.LinkedList.nodeMap[JSON.stringify(block.id)] = block;
+    updatedBlock.listIndex = block.listIndex || undefined;
     return { node: updatedBlock, pageId };
   }
 
@@ -125,7 +125,7 @@ export class EditorCRDT extends CRDT<Block> {
     updatedBlock.indent = block.indent;
     updatedBlock.style = block.style;
     updatedBlock.type = block.type;
-    // this.LinkedList.nodeMap[JSON.stringify(block.id)] = block;
+    updatedBlock.listIndex = block.listIndex || undefined;
     return { node: updatedBlock, pageId };
   }
 
@@ -136,14 +136,10 @@ export class EditorCRDT extends CRDT<Block> {
     newNode.next = operation.node.next;
     newNode.prev = operation.node.prev;
     newNode.indent = operation.node.indent;
+    newNode.listIndex = operation.node.listIndex || undefined;
     this.LinkedList.insertById(newNode);
 
     this.clock = Math.max(this.clock, operation.node.id.clock) + 1;
-    /*
-    if (this.clock <= newNode.id.clock) {
-      this.clock = newNode.id.clock + 1;
-    }
-      */
   }
 
   remoteDelete(operation: RemoteBlockDeleteOperation): void {
@@ -153,11 +149,6 @@ export class EditorCRDT extends CRDT<Block> {
       this.LinkedList.deleteNode(targetNodeId);
     }
     this.clock = Math.max(this.clock, clock) + 1;
-    /*
-    if (this.clock <= clock) {
-      this.clock = clock + 1;
-    }
-      */
   }
 
   localReorder(params: {

--- a/@noctaCrdt/LinkedList.ts
+++ b/@noctaCrdt/LinkedList.ts
@@ -55,65 +55,9 @@ export abstract class LinkedList<T extends Node<NodeId>> {
     delete this.nodeMap[JSON.stringify(id)];
   }
 
-  reorderNodes({ targetId, beforeId, afterId }: ReorderNodesProps): void {
-    const targetNode = this.getNode(targetId);
-    if (!targetNode) return;
+  updateAllOrderedListIndices() {}
 
-    // 1. 기존 연결 해제
-    if (targetNode.prev) {
-      const prevNode = this.getNode(targetNode.prev);
-      if (prevNode) {
-        prevNode.next = targetNode.next;
-      }
-    } else {
-      this.head = targetNode.next;
-    }
-
-    if (targetNode.next) {
-      const nextNode = this.getNode(targetNode.next);
-      if (nextNode) {
-        nextNode.prev = targetNode.prev;
-      }
-    }
-
-    // 2. 새로운 위치에 연결
-    if (!beforeId) {
-      // 맨 앞으로 이동
-      const oldHead = this.head;
-      this.head = targetId;
-      targetNode.prev = null;
-      targetNode.next = oldHead;
-
-      if (oldHead) {
-        const headNode = this.getNode(oldHead);
-        if (headNode) {
-          headNode.prev = targetId;
-        }
-      }
-    } else if (!afterId) {
-      // 맨 끝으로 이동
-      const beforeNode = this.getNode(beforeId);
-      if (beforeNode) {
-        beforeNode.next = targetId;
-        targetNode.prev = beforeId;
-        targetNode.next = null;
-      }
-    } else {
-      // 중간으로 이동
-      const beforeNode = this.getNode(beforeId);
-      const afterNode = this.getNode(afterId);
-
-      if (beforeNode && afterNode) {
-        targetNode.prev = beforeId;
-        targetNode.next = afterId;
-        beforeNode.next = targetId;
-        afterNode.prev = targetId;
-      }
-    }
-
-    // 노드맵 갱신
-    this.setNode(targetId, targetNode);
-  }
+  reorderNodes({ targetId, beforeId, afterId }: ReorderNodesProps): void {}
 
   findByIndex(index: number): T {
     if (index < 0) {
@@ -299,6 +243,116 @@ export abstract class LinkedList<T extends Node<NodeId>> {
 }
 
 export class BlockLinkedList extends LinkedList<Block> {
+  updateAllOrderedListIndices() {
+    let currentNode = this.getNode(this.head);
+    let currentIndex = 1;
+
+    while (currentNode) {
+      if (currentNode.type === "ol") {
+        const prevNode = currentNode.prev ? this.getNode(currentNode.prev) : null;
+
+        if (!prevNode || prevNode.type !== "ol") {
+          // 이전 노드가 없거나 ol이 아닌 경우 1부터 시작
+          currentIndex = 1;
+        } else if (prevNode.indent !== currentNode.indent) {
+          // indent가 다른 경우
+          if (currentNode.indent > prevNode.indent) {
+            // indent가 증가한 경우 1부터 시작
+            currentIndex = 1;
+          } else {
+            // indent가 감소한 경우 같은 indent를 가진 이전 ol의 번호 다음부터 시작
+            let prevSameIndentNode = prevNode;
+            while (
+              prevSameIndentNode &&
+              (prevSameIndentNode.indent !== currentNode.indent || prevSameIndentNode.type !== "ol")
+            ) {
+              if (prevSameIndentNode.prev) {
+                prevSameIndentNode = this.getNode(prevSameIndentNode.prev)!;
+              } else {
+                break;
+              }
+            }
+
+            if (prevSameIndentNode && prevSameIndentNode.type === "ol") {
+              currentIndex = prevSameIndentNode.listIndex! + 1;
+            } else {
+              currentIndex = 1;
+            }
+          }
+        } else {
+          // 같은 indent의 연속된 ol인 경우 번호 증가
+          currentIndex = prevNode.listIndex!;
+          currentIndex += 1;
+        }
+
+        currentNode.listIndex = currentIndex;
+      }
+
+      currentNode = currentNode.next ? this.getNode(currentNode.next) : null;
+    }
+  }
+
+  reorderNodes({ targetId, beforeId, afterId }: ReorderNodesProps) {
+    const targetNode = this.getNode(targetId);
+    if (!targetNode) return;
+
+    // 1. 현재 위치에서 노드 제거
+    if (targetNode.prev) {
+      const prevNode = this.getNode(targetNode.prev);
+      if (prevNode) prevNode.next = targetNode.next;
+    }
+
+    if (targetNode.next) {
+      const nextNode = this.getNode(targetNode.next);
+      if (nextNode) nextNode.prev = targetNode.prev;
+    }
+
+    if (this.head === targetId) {
+      this.head = targetNode.next;
+    }
+
+    // 2. 새로운 위치에 노드 삽입
+    if (!beforeId) {
+      // 맨 앞으로 이동
+      const oldHead = this.head;
+      this.head = targetId;
+      targetNode.prev = null;
+      targetNode.next = oldHead;
+
+      if (oldHead) {
+        const headNode = this.getNode(oldHead);
+        if (headNode) headNode.prev = targetId;
+      }
+    } else if (!afterId) {
+      // 맨 끝으로 이동
+      const beforeNode = this.getNode(beforeId);
+      if (beforeNode) {
+        beforeNode.next = targetId;
+        targetNode.prev = beforeId;
+        targetNode.next = null;
+      }
+    } else {
+      // 중간으로 이동
+      const beforeNode = this.getNode(beforeId);
+      const afterNode = this.getNode(afterId);
+
+      if (beforeNode && afterNode) {
+        targetNode.prev = beforeId;
+        targetNode.next = afterId;
+        beforeNode.next = targetId;
+        afterNode.prev = targetId;
+      }
+    }
+
+    // 노드맵 갱신
+    this.setNode(targetId, targetNode);
+
+    // ordered list가 포함된 경우 전체 인덱스 재계산
+    if (targetNode.type === "ol") {
+      this.updateAllOrderedListIndices();
+    }
+  }
+
   deserializeNodeId(data: any): BlockId {
     return BlockId.deserialize(data);
   }

--- a/@noctaCrdt/Node.ts
+++ b/@noctaCrdt/Node.ts
@@ -50,6 +50,7 @@ export class Block extends Node<BlockId> {
   style: string[];
   icon: string;
   crdt: BlockCRDT;
+  listIndex?: number;
 
   constructor(value: string, id: BlockId) {
     super(value, id);
@@ -70,6 +71,7 @@ export class Block extends Node<BlockId> {
       style: this.style,
       icon: this.icon,
       crdt: this.crdt.serialize(),
+      listIndex: this.listIndex ? this.listIndex : null,
     };
   }
 
@@ -84,6 +86,7 @@ export class Block extends Node<BlockId> {
     block.style = data.style;
     block.icon = data.icon;
     block.crdt = BlockCRDT.deserialize(data.crdt);
+    block.listIndex = data.listIndex ? data.listIndex : null;
     return block;
   }
 }

--- a/client/src/features/editor/components/IconBlock/IconBlock.tsx
+++ b/client/src/features/editor/components/IconBlock/IconBlock.tsx
@@ -3,7 +3,7 @@ import { iconContainerStyle, iconStyle } from "./IconBlock.style";
 
 interface IconBlockProps {
   type: ElementType;
-  index?: number;
+  index: number | undefined;
 }
 
 export const IconBlock = ({ type, index = 1 }: IconBlockProps) => {

--- a/client/src/features/editor/components/block/Block.tsx
+++ b/client/src/features/editor/components/block/Block.tsx
@@ -229,7 +229,7 @@ export const Block: React.FC<BlockProps> = memo(
             onCopySelect={handleCopySelect}
             onDeleteSelect={handleDeleteSelect}
           />
-          <IconBlock type={block.type} index={1} />
+          <IconBlock type={block.type} index={block.listIndex} />
           <div
             ref={blockRef}
             onKeyDown={(e) => onKeyDown(e, blockRef.current, block)}

--- a/client/src/features/editor/hooks/useBlockOption.ts
+++ b/client/src/features/editor/hooks/useBlockOption.ts
@@ -119,6 +119,8 @@ export const useBlockOptionSelect = ({
     });
 
     editorCRDT.currentBlock = operation.node;
+    // ol 노드의 index를 다시 설정
+    editorCRDT.LinkedList.updateAllOrderedListIndices();
     setEditorState({
       clock: editorCRDT.clock,
       linkedList: editorCRDT.LinkedList,
@@ -145,6 +147,9 @@ export const useBlockOptionSelect = ({
       const prevBlock = findBlock(editorCRDT.LinkedList, currentIndex - 1); // ✅ 이미 삭제한 후라, prev는 currentIndex - 1
       editorCRDT.currentBlock = nextBlock || prevBlock || null;
     }
+
+    // ol 노드의 index를 다시 설정
+    editorCRDT.LinkedList.updateAllOrderedListIndices();
 
     setEditorState({
       clock: editorCRDT.clock,

--- a/client/src/features/editor/hooks/useMarkdownGrammer.ts
+++ b/client/src/features/editor/hooks/useMarkdownGrammer.ts
@@ -256,16 +256,23 @@ export const useMarkdownGrammer = ({
                 break;
               }
               if (currentBlock.type !== "p") {
+                const wasOrderedList = currentBlock.type === "ol";
                 currentBlock.type = "p";
                 sendBlockUpdateOperation(editorCRDT.localUpdate(currentBlock, pageId));
                 editorCRDT.currentBlock = currentBlock;
+                if (wasOrderedList) {
+                  editorCRDT.LinkedList.updateAllOrderedListIndices();
+                }
                 updateEditorState();
                 break;
               }
               // FIX: 서윤님 피드백 반영
               const prevBlock =
                 currentIndex > 0 ? editorCRDT.LinkedList.findByIndex(currentIndex - 1) : null;
-
+              const nextBlock =
+                currentIndex < editorCRDT.LinkedList.spread().length - 1
+                  ? editorCRDT.LinkedList.findByIndex(currentIndex + 1)
+                  : null;
               if (prevBlock) {
                 let targetIndex = currentIndex - 1;
                 let targetBlock = findBlock(targetIndex);
@@ -304,8 +311,10 @@ export const useMarkdownGrammer = ({
                 editorCRDT.currentBlock = prevBlock;
                 editorCRDT.currentBlock.crdt.currentCaret = prevBlockEndCaret;
                 sendBlockDeleteOperation(editorCRDT.localDelete(currentIndex, undefined, pageId));
-
                 updateEditorState();
+                if (prevBlock.type === "ol" && nextBlock?.type === "ol") {
+                  editorCRDT.LinkedList.updateAllOrderedListIndices();
+                }
                 e.preventDefault();
               }
             }


### PR DESCRIPTION
## 📝 변경 사항

- #11 

## 🔍 변경 사항 설명

- 순서있는 리스트 생성시 순서를 반영해서 iconBlock의 숫자를 갱신합니다.
  - 리스트 생성시, 이전 인덱스보다 1 증가시켜서 생성
  - 리스트 중간에서 기본 블록으로 변경할 때, 두 리스트로 분할해서 각각 1부터 시작
  - indent 증가시 1부터 시작
  - indent 감소시 기존 순서에 맞게 변경
  - 두개의 순서 리스트 병합시, 먼저 있는 리스트에 합쳐서 숫자 시작

CRDT의 BlockLinkedList에 `updateAllOrderedListIndices` 메서드를 구현해서 현재 연산이 순서 리스트일 경우, 모든 블록을 순회하며 리스트의 index를 갱신합니다. 기존에는 각 케이스별로 코드를 작성했는데 이렇게 하다보니까 에러도 많이 발생하고 코드의 길이가 늘어나서 LinkedList 메서드로 분리해서 사용하는 식으로 구현했습니다.
블록을 모두 순회하는 로직이다보니 자주 실행하면 성능에 영향을 줄 수 있을것 같아 순서리스트 연산일때만 실행시키도록 분기 처리했습니다.

## 🙏 질문 사항

- 혹시 엣지케이스나 에러케이스 등 문제가 발생하는 부분이 있으면 피드백 부탁드립니다!

## 📷 스크린샷 (선택)

https://github.com/user-attachments/assets/7a9c6ab4-d64f-4756-a96f-37a5a1188f3a

## ✅ 작성자 체크리스트

- [x] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [x] 로컬에서 모든 기능이 정상 작동함
- [x] 린터 및 포맷터로 코드 정리됨
- [ ] 의존성 업데이트 확인
- [ ] 문서 업데이트 또는 주석 추가 (필요 시)
