### PR TITLE
Hotfix/#220 특수문자 있는 경우에도 텍스트 드래그 되도록 수정

### DIFF
--- a/client/src/features/editor/components/block/Block.style.ts
+++ b/client/src/features/editor/components/block/Block.style.ts
@@ -64,6 +64,8 @@ export const textContainerStyle = cva({
   base: {
     ...baseTextStyle,
     position: "relative",
+    overflowWrap: "break-word",
+    whiteSpace: "pre-wrap",
     "&:empty::before": {
       color: "gray.300",
       pointerEvents: "none",

--- a/client/src/features/editor/utils/domSyncUtils.ts
+++ b/client/src/features/editor/utils/domSyncUtils.ts
@@ -111,7 +111,7 @@ export const setInnerHTML = ({ element, block }: SetInnerHTMLProps): void => {
     }
 
     // 텍스트 추가
-    html += char.value;
+    html += sanitizeText(char.value);
 
     // 다음 문자로 넘어가기 전에 현재 상태 업데이트
     currentState = targetState;
@@ -137,6 +137,11 @@ const setsEqual = (a: Set<string>, b: Set<string>): boolean => {
   }
   return true;
 };
+
+const sanitizeText = (text: string): string => {
+  return text.replace(/<br>/g, "\u00A0");
+};
+
 // 배열 비교 헬퍼 함수
 export const arraysEqual = (a: string[], b: string[]): boolean => {
   if (a.length !== b.length) return false;

--- a/client/src/features/editor/utils/domSyncUtils.ts
+++ b/client/src/features/editor/utils/domSyncUtils.ts
@@ -111,7 +111,7 @@ export const setInnerHTML = ({ element, block }: SetInnerHTMLProps): void => {
     }
 
     // 텍스트 추가
-    html += sanitizeText(char.value);
+    html += char.value;
 
     // 다음 문자로 넘어가기 전에 현재 상태 업데이트
     currentState = targetState;
@@ -137,17 +137,6 @@ const setsEqual = (a: Set<string>, b: Set<string>): boolean => {
   }
   return true;
 };
-
-const sanitizeText = (text: string): string => {
-  return text
-    .replace(/<br>/g, "&nbsp;")
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
-};
-
 // 배열 비교 헬퍼 함수
 export const arraysEqual = (a: string[], b: string[]): boolean => {
   if (a.length !== b.length) return false;


### PR DESCRIPTION
## 📝 변경 사항

- #220

## 🔍 변경 사항 설명

- `sanitizeText` 함수로 특수문자를 html 엔티티로 변경하는 부분에서 문제가 발생했습니다.
- 블록의 style에 `whiteSpace: "pre-wrap"` 속성을 추가하여 공백과 줄바꿈 문자가 유지되도록 수정했습니다.

## 🙏 질문 사항

## 📷 스크린샷 (선택)

https://github.com/user-attachments/assets/cfec631a-a4be-4a27-977d-0a68b52259ba

## ✅ 작성자 체크리스트

- [x] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [x] 로컬에서 모든 기능이 정상 작동함
- [x] 린터 및 포맷터로 코드 정리됨
- [ ] 의존성 업데이트 확인
- [ ] 문서 업데이트 또는 주석 추가 (필요 시)
