### PR TITLE
Feature/#231_remote페이지_제목_반영_안되는_버그 및 아이콘 반영 버그 수정

### DIFF
--- a/client/src/components/sidebar/components/pageItem/PageItem.tsx
+++ b/client/src/components/sidebar/components/pageItem/PageItem.tsx
@@ -1,5 +1,5 @@
 import { PageIconType } from "@noctaCrdt/Interfaces";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import CloseIcon from "@assets/icons/close.svg?react";
 import { useModal } from "@src/components/modal/useModal";
 import { PageIconButton } from "../pageIconButton/PageIconButton";
@@ -29,7 +29,11 @@ export const PageItem = ({
 }: PageItemProps) => {
   const { isOpen, openModal, closeModal } = useModal();
   const [pageIcon, setPageIcon] = useState<PageIconType>(icon);
-  // 삭제 버튼 클릭 핸들러
+
+  useEffect(() => {
+    setPageIcon(icon);
+  }, [icon]);
+
   const handleDelete = (e: React.MouseEvent) => {
     e.stopPropagation(); // 상위 요소로의 이벤트 전파 중단
     onDelete?.(id);

--- a/client/src/features/editor/Editor.tsx
+++ b/client/src/features/editor/Editor.tsx
@@ -47,14 +47,13 @@ export const Editor = ({ onTitleChange, pageId, pageTitle, serializedEditorData 
   const [displayTitle, setDisplayTitle] = useState(pageTitle);
   const [dragBlockList, setDragBlockList] = useState<string[]>([]);
 
+  useEffect(() => {
     if (pageTitle === "새로운 페이지" || pageTitle === "") {
       setDisplayTitle("");
     } else {
       setDisplayTitle(pageTitle);
     }
   }, [pageTitle]);
-
-
 
   const editorCRDTInstance = useMemo(() => {
     let newEditorCRDT;

--- a/client/src/features/editor/Editor.tsx
+++ b/client/src/features/editor/Editor.tsx
@@ -44,10 +44,15 @@ export const Editor = ({ onTitleChange, pageId, pageTitle, serializedEditorData 
     sendBlockUpdateOperation,
   } = useSocketStore();
   const { clientId } = useSocketStore();
+  const [displayTitle, setDisplayTitle] = useState(pageTitle);
 
-  const [displayTitle, setDisplayTitle] = useState(
-    pageTitle === "새로운 페이지" || pageTitle === "" ? "" : pageTitle,
-  );
+  useEffect(() => {
+    if (pageTitle === "새로운 페이지" || pageTitle === "") {
+      setDisplayTitle("");
+    } else {
+      setDisplayTitle(pageTitle);
+    }
+  }, [pageTitle]);
 
   const editorCRDTInstance = useMemo(() => {
     let newEditorCRDT;


### PR DESCRIPTION
- #231
- #233




## 📝 변경 사항

- 다른 사용자가 페이지 제목을 바꾸면 로컬의 페이지 제목도 바로 바뀌도록 수정했습니다.
  - 새로운 페이지일때는 빈칸이 들어가도록 수정했습니다.

https://github.com/user-attachments/assets/00d741cf-f3ab-41e8-bd02-0711436b805e


- 사이드바 아이콘 동기화 안되는 버그 수정

https://github.com/user-attachments/assets/63a3acfd-2001-468e-8244-a7d5f1a68ec4

## 🔍 변경 사항 설명

- useEffect로 의존성 주입하였습니다.

## 🙏 질문 사항

- [ ] 리뷰어에게 부탁하고싶은 체크리스트를 추가합니다.

## 📷 스크린샷 (선택)

- UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

## ✅ 작성자 체크리스트

- [x] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [x] 로컬에서 모든 기능이 정상 작동함
- [x] 린터 및 포맷터로 코드 정리됨
- [x] 의존성 업데이트 확인
- [ ] 문서 업데이트 또는 주석 추가 (필요 시)
