### PR TITLE
Feature/#234 페이지 삭제시, 삭제 토글창 알림

### DIFF
--- a/@noctaCrdt/Interfaces.ts
+++ b/@noctaCrdt/Interfaces.ts
@@ -80,6 +80,7 @@ export interface RemotePageDeleteOperation {
   type: "pageDelete";
   clientId: number;
   workspaceId: string;
+  pageTitle: string;
   pageId: string;
 }
 

--- a/client/src/components/Toast/Toast.style.ts
+++ b/client/src/components/Toast/Toast.style.ts
@@ -1,0 +1,33 @@
+import { css } from "@styled-system/css";
+
+export const ToastWrapper = css({
+  display: "flex",
+  // position: "relative", // progress bar를 위한 position 설정
+  gap: "2",
+  alignItems: "center",
+  borderRadius: "lg",
+  width: "fit-content",
+  paddingBlock: "2",
+  paddingInline: "4",
+  color: "white",
+  backgroundColor: "gray.700",
+  boxShadow: "lg",
+  // overflow: "hidden", // progress bar가 넘치지 않도록
+  transition: "all",
+  transitionDuration: "300ms",
+});
+
+export const CloseItemBox = css({
+  width: "15px",
+  height: "15px",
+});
+
+export const ToastProgress = css({
+  position: "absolute",
+  left: "0px",
+  bottom: "0px",
+  borderRadius: "lg",
+  width: "100%",
+  height: "6px",
+  backgroundColor: "blue",
+});

--- a/client/src/components/Toast/Toast.tsx
+++ b/client/src/components/Toast/Toast.tsx
@@ -34,13 +34,14 @@ export const Toast = ({ message, duration = 3000, onClose }: ToastProps) => {
   };
   if (!isVisible) return null;
   return (
-    <div
+    <motion.div
       className={ToastWrapper}
       style={{
         opacity: isClosing ? 0 : 1,
         transform: isClosing ? "translateY(100%)" : "translateY(0)",
         transition: "all 0.3s ease-in-out",
       }}
+      exit={{ opacity: 0 }}
     >
       <motion.div
         initial={{ width: "0%" }}
@@ -53,6 +54,6 @@ export const Toast = ({ message, duration = 3000, onClose }: ToastProps) => {
       <div className={CloseItemBox} onClick={handleClose}>
         <CloseIcon />
       </div>
-    </div>
+    </motion.div>
   );
 };

--- a/client/src/components/Toast/Toast.tsx
+++ b/client/src/components/Toast/Toast.tsx
@@ -1,0 +1,58 @@
+import { motion } from "framer-motion";
+import { useState, useEffect } from "react";
+import CloseIcon from "@assets/icons/close.svg?react";
+import { ToastWrapper, CloseItemBox, ToastProgress } from "./Toast.style";
+
+interface ToastProps {
+  message: string;
+  duration?: number;
+  onClose: () => void;
+}
+
+export const Toast = ({ message, duration = 3000, onClose }: ToastProps) => {
+  const [isVisible, setIsVisible] = useState(true);
+  const [isClosing, setIsClosing] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsClosing(true);
+      setTimeout(() => {
+        setIsVisible(false);
+        onClose();
+      }, 300);
+    }, duration);
+
+    return () => clearTimeout(timer);
+  }, [duration, onClose]);
+
+  const handleClose = () => {
+    setIsClosing(true);
+    setTimeout(() => {
+      setIsVisible(false);
+      onClose();
+    }, 300);
+  };
+  if (!isVisible) return null;
+  return (
+    <div
+      className={ToastWrapper}
+      style={{
+        opacity: isClosing ? 0 : 1,
+        transform: isClosing ? "translateY(100%)" : "translateY(0)",
+        transition: "all 0.3s ease-in-out",
+      }}
+    >
+      <motion.div
+        initial={{ width: "0%" }}
+        animate={{ width: "100%" }}
+        transition={{ duration: duration / 1000, ease: "easeOut" }}
+        className={ToastProgress}
+      />
+
+      <span className="text-sm">{message}</span>
+      <div className={CloseItemBox} onClick={handleClose}>
+        <CloseIcon />
+      </div>
+    </div>
+  );
+};

--- a/client/src/components/Toast/ToastContainer.style.ts
+++ b/client/src/components/Toast/ToastContainer.style.ts
@@ -1,0 +1,11 @@
+import { css } from "@styled-system/css";
+
+export const ToastContainerStyle = css({
+  display: "flex",
+  zIndex: "9999",
+  position: "fixed",
+  right: "6",
+  bottom: "6",
+  gap: "2",
+  flexDirection: "column-reverse",
+});

--- a/client/src/components/Toast/ToastContainer.tsx
+++ b/client/src/components/Toast/ToastContainer.tsx
@@ -1,0 +1,20 @@
+import { useToastStore } from "@stores/useToastStore";
+import { Toast } from "./Toast";
+import { ToastContainerStyle } from "./ToastContainer.style";
+
+export const ToastContainer = () => {
+  const { toasts, removeToast } = useToastStore();
+
+  return (
+    <div className={ToastContainerStyle}>
+      {toasts.map((toast) => (
+        <Toast
+          key={toast.id}
+          message={toast.message}
+          duration={toast.duration}
+          onClose={() => removeToast(toast.id)}
+        />
+      ))}
+    </div>
+  );
+};

--- a/client/src/components/Toast/ToastContainer.tsx
+++ b/client/src/components/Toast/ToastContainer.tsx
@@ -1,3 +1,4 @@
+import { AnimatePresence } from "framer-motion";
 import { useToastStore } from "@stores/useToastStore";
 import { Toast } from "./Toast";
 import { ToastContainerStyle } from "./ToastContainer.style";
@@ -7,14 +8,16 @@ export const ToastContainer = () => {
 
   return (
     <div className={ToastContainerStyle}>
-      {toasts.map((toast) => (
-        <Toast
-          key={toast.id}
-          message={toast.message}
-          duration={toast.duration}
-          onClose={() => removeToast(toast.id)}
-        />
-      ))}
+      <AnimatePresence>
+        {toasts.map((toast) => (
+          <Toast
+            key={toast.id}
+            message={toast.message}
+            duration={toast.duration}
+            onClose={() => removeToast(toast.id)}
+          />
+        ))}
+      </AnimatePresence>
     </div>
   );
 };

--- a/client/src/components/sidebar/Sidebar.tsx
+++ b/client/src/components/sidebar/Sidebar.tsx
@@ -7,7 +7,6 @@ import { useModal } from "@components/modal/useModal";
 import { MAX_VISIBLE_PAGE } from "@src/constants/page";
 import { AuthButton } from "@src/features/auth/AuthButton";
 import { useSocketStore } from "@src/stores/useSocketStore";
-import { useToastStore } from "@src/stores/useToastStore";
 import { Page } from "@src/types/page";
 import { useIsSidebarOpen, useSidebarActions } from "@stores/useSidebarStore";
 import { animation, contentVariants, sidebarVariants } from "./Sidebar.animation";
@@ -43,7 +42,6 @@ export const Sidebar = ({
   const { isOpen, openModal, closeModal } = useModal();
   const { sendPageDeleteOperation, clientId } = useSocketStore();
 
-  const { addToast } = useToastStore();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [pageToDelete, setPageToDelete] = useState<Page | null>(null);
 
@@ -69,11 +67,10 @@ export const Sidebar = ({
       return;
     }
 
-    addToast(`페이지(${pageToDelete!.title})가 삭제되었습니다.`);
-
     sendPageDeleteOperation({
       type: "pageDelete",
       workspaceId: "default",
+      pageTitle: pageToDelete!.title,
       pageId,
       clientId,
     });

--- a/client/src/components/sidebar/Sidebar.tsx
+++ b/client/src/components/sidebar/Sidebar.tsx
@@ -7,6 +7,7 @@ import { useModal } from "@components/modal/useModal";
 import { MAX_VISIBLE_PAGE } from "@src/constants/page";
 import { AuthButton } from "@src/features/auth/AuthButton";
 import { useSocketStore } from "@src/stores/useSocketStore";
+import { useToastStore } from "@src/stores/useToastStore";
 import { Page } from "@src/types/page";
 import { useIsSidebarOpen, useSidebarActions } from "@stores/useSidebarStore";
 import { animation, contentVariants, sidebarVariants } from "./Sidebar.animation";
@@ -42,6 +43,7 @@ export const Sidebar = ({
   const { isOpen, openModal, closeModal } = useModal();
   const { sendPageDeleteOperation, clientId } = useSocketStore();
 
+  const { addToast } = useToastStore();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [pageToDelete, setPageToDelete] = useState<Page | null>(null);
 
@@ -66,6 +68,8 @@ export const Sidebar = ({
       console.error("Client ID not assigned");
       return;
     }
+
+    addToast(`페이지(${pageToDelete!.title})가 삭제되었습니다.`);
 
     sendPageDeleteOperation({
       type: "pageDelete",

--- a/client/src/components/sidebar/components/pageItem/PageItem.tsx
+++ b/client/src/components/sidebar/components/pageItem/PageItem.tsx
@@ -29,7 +29,7 @@ export const PageItem = ({
 }: PageItemProps) => {
   const { isOpen, openModal, closeModal } = useModal();
   const [pageIcon, setPageIcon] = useState<PageIconType>(icon);
-  // 삭제 버튼 클릭 핸들러
+
   const handleDelete = (e: React.MouseEvent) => {
     e.stopPropagation(); // 상위 요소로의 이벤트 전파 중단
     onDelete?.(id);

--- a/client/src/features/workSpace/WorkSpace.tsx
+++ b/client/src/features/workSpace/WorkSpace.tsx
@@ -5,6 +5,7 @@ import { BottomNavigator } from "@components/bottomNavigator/BottomNavigator";
 import { ErrorModal } from "@components/modal/ErrorModal";
 import { Sidebar } from "@components/sidebar/Sidebar";
 import { Page } from "@features/page/Page";
+import { ToastContainer } from "@src/components/Toast/ToastContainer";
 import { useSocketStore } from "@src/stores/useSocketStore";
 import { workSpaceContainer, content } from "./WorkSpace.style";
 import { IntroScreen } from "./components/IntroScreen";
@@ -45,6 +46,7 @@ export const WorkSpace = () => {
 
   return (
     <>
+      <ToastContainer />
       <AnimatePresence mode="wait">{isLoading && <IntroScreen />}</AnimatePresence>
       <div
         className={workSpaceContainer({

--- a/client/src/features/workSpace/hooks/usePagesManage.ts
+++ b/client/src/features/workSpace/hooks/usePagesManage.ts
@@ -8,6 +8,7 @@ import { Page as CRDTPage } from "@noctaCrdt/Page";
 import { WorkSpace } from "@noctaCrdt/WorkSpace";
 import { useEffect, useState, useRef, useCallback } from "react";
 import { useSocketStore } from "@src/stores/useSocketStore";
+import { useToastStore } from "@src/stores/useToastStore";
 import { Page } from "@src/types/page";
 
 const PAGE_OFFSET = 60;
@@ -17,6 +18,7 @@ export const usePagesManage = (workspace: WorkSpace | null, clientId: number | n
   const { subscribeToPageOperations, sendPageCreateOperation, sendPageUpdateOperation } =
     useSocketStore();
   const subscriptionRef = useRef(false);
+  const { addToast } = useToastStore();
   useEffect(() => {
     if (!workspace) return;
     if (subscriptionRef.current) return;
@@ -52,6 +54,7 @@ export const usePagesManage = (workspace: WorkSpace | null, clientId: number | n
         addPage(newPage);
       },
       onRemotePageDelete: (operation) => {
+        addToast(`${operation.clientId}번 유저가 페이지(${operation.pageTitle})를 삭제하였습니다.`);
         workspace.remotePageDelete?.({
           pageId: operation.pageId,
           workspaceId: operation.workspaceId,

--- a/client/src/stores/useToastStore.ts
+++ b/client/src/stores/useToastStore.ts
@@ -1,0 +1,20 @@
+import { create } from "zustand";
+import { Toast } from "../types/toast";
+
+interface ToastStore {
+  toasts: Toast[];
+  addToast: (message: string, duration?: number) => void;
+  removeToast: (id: number) => void;
+}
+
+export const useToastStore = create<ToastStore>((set) => ({
+  toasts: [],
+  addToast: (message, duration = 3000) =>
+    set((state) => ({
+      toasts: [...state.toasts, { id: Date.now(), message, duration }],
+    })),
+  removeToast: (id) =>
+    set((state) => ({
+      toasts: state.toasts.filter((toast) => toast.id !== id),
+    })),
+}));

--- a/client/src/stores/useToastStore.ts
+++ b/client/src/stores/useToastStore.ts
@@ -9,10 +9,19 @@ interface ToastStore {
 
 export const useToastStore = create<ToastStore>((set) => ({
   toasts: [],
-  addToast: (message, duration = 3000) =>
+  addToast: (message, duration = 3000) => {
+    const id = Date.now();
     set((state) => ({
-      toasts: [...state.toasts, { id: Date.now(), message, duration }],
-    })),
+      toasts: [...state.toasts, { id, message, duration }],
+    }));
+    // duration 후에 자동으로 해당 toast 제거
+    setTimeout(() => {
+      set((state) => ({
+        toasts: state.toasts.filter((toast) => toast.id !== id),
+      }));
+    }, duration);
+  },
+
   removeToast: (id) =>
     set((state) => ({
       toasts: state.toasts.filter((toast) => toast.id !== id),

--- a/client/src/types/toast.ts
+++ b/client/src/types/toast.ts
@@ -1,0 +1,5 @@
+export interface Toast {
+  id: number;
+  message: string;
+  duration: number;
+}

--- a/server/src/crdt/crdt.gateway.ts
+++ b/server/src/crdt/crdt.gateway.ts
@@ -280,13 +280,14 @@ export class CrdtGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
       if (pageIndex === -1) {
         throw new Error(`Page with id ${data.pageId} not found`);
       }
-      // pageList에서 페이지 제거
+      const pageTitle = (await this.workSpaceService.getPage(userId, data.pageId)).title;
       currentWorkspace.pageList.splice(pageIndex, 1);
 
       const operation = {
         type: "pageDelete",
         workspaceId: data.workspaceId,
         pageId: data.pageId,
+        pageTitle,
         clientId: data.clientId,
       } as RemotePageDeleteOperation;
       client.emit("delete/page", operation);


### PR DESCRIPTION
- #234 

## 📝 변경 사항

https://github.com/user-attachments/assets/e57ffdef-1a11-407c-8606-99ab7e2c1fb0


- 페이지가 삭제될때 화면 우측 하단에 toast 토글창을 생성합니다.

## 🔍 변경 사항 설명

- toast 컴포넌트 생성, toast 컨테이너 컴포넌트 생성
- useToastStore로 선언하여 원하는 메세지를 addToast로 표시 가능.
- delete/page 할때 pageTitle도 보내게 변경

## 🙏 질문 사항

- [ ] 사라지는 시간을 3초로 했는데 적당한지 동작확인 부탁드립니다!!!
- [ ] 토스트 토글창에 표시되는 메세지가 적절한지 확인 부탁드립니다.
- [ ] 또한 userId로 했는데 추후에는 user의 이름을 넘기변 반영할 수 있을듯합니다.

## 📷 스크린샷 (선택)

- UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

## ✅ 작성자 체크리스트

- [x] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [x] 로컬에서 모든 기능이 정상 작동함
- [x] 린터 및 포맷터로 코드 정리됨
- [x] 의존성 업데이트 확인
- [ ] 문서 업데이트 또는 주석 추가 (필요 시)
