### PR TITLE
Hotfix/#248 같은블록 동시입력시 캐럿이 튀는 문제 수정

### DIFF
--- a/client/src/features/editor/hooks/useBlockDragAndDrop.ts
+++ b/client/src/features/editor/hooks/useBlockDragAndDrop.ts
@@ -1,18 +1,19 @@
 import { DragEndEvent, DragStartEvent, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
 import { EditorCRDT } from "@noctaCrdt/Crdt";
 import { Block } from "@noctaCrdt/Node";
-import { useSocketStore } from "@src/stores/useSocketStore.ts";
-import { EditorStateProps } from "../Editor";
 import {
   RemoteBlockReorderOperation,
   RemoteBlockUpdateOperation,
 } from "node_modules/@noctaCrdt/Interfaces";
+import { useSocketStore } from "@src/stores/useSocketStore.ts";
+import { EditorStateProps } from "../Editor";
 
 interface UseBlockDragAndDropProps {
   editorCRDT: EditorCRDT;
   editorState: EditorStateProps;
   setEditorState: React.Dispatch<React.SetStateAction<EditorStateProps>>;
   pageId: string;
+  isLocalChange: React.MutableRefObject<boolean>;
 }
 
 export const useBlockDragAndDrop = ({
@@ -20,6 +21,7 @@ export const useBlockDragAndDrop = ({
   editorState,
   setEditorState,
   pageId,
+  isLocalChange,
 }: UseBlockDragAndDropProps) => {
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -123,6 +125,7 @@ export const useBlockDragAndDrop = ({
     if (disableDrag) return;
 
     try {
+      isLocalChange.current = true;
       const nodes = editorState.linkedList.spread();
 
       // ID 문자열에서 client와 clock 추출
@@ -203,6 +206,7 @@ export const useBlockDragAndDrop = ({
       );
 
       if (parentIndex === -1) return [];
+      isLocalChange.current = true;
 
       const childBlockIds = [];
 

--- a/client/src/features/editor/hooks/useBlockOperation.ts
+++ b/client/src/features/editor/hooks/useBlockOperation.ts
@@ -14,6 +14,7 @@ interface UseBlockOperationProps {
   setEditorState: React.Dispatch<React.SetStateAction<EditorStateProps>>;
   onKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
   handleHrInput: (block: Block, content: string) => boolean;
+  isLocalChange: React.MutableRefObject<boolean>;
 }
 
 export const useBlockOperation = ({
@@ -22,12 +23,14 @@ export const useBlockOperation = ({
   setEditorState,
   onKeyDown,
   handleHrInput,
+  isLocalChange,
 }: UseBlockOperationProps) => {
   const { sendCharInsertOperation, sendCharDeleteOperation } = useSocketStore();
 
   const handleBlockClick = useCallback(
     (blockId: BlockId, e: React.MouseEvent<HTMLDivElement>) => {
       if (editorCRDT) {
+        isLocalChange.current = true;
         const selection = window.getSelection();
         if (!selection) return;
 
@@ -52,6 +55,7 @@ export const useBlockOperation = ({
       if ((e.nativeEvent as InputEvent).isComposing) {
         return;
       }
+      isLocalChange.current = true;
 
       let operationNode;
       const element = e.currentTarget;
@@ -79,6 +83,7 @@ export const useBlockOperation = ({
               currentContent.length - 1,
             );
           }
+          console.log("prevChar", prevChar);
           const addedChar = newContent[newContent.length - 1];
           charNode = block.crdt.localInsert(
             currentContent.length,
@@ -236,13 +241,14 @@ export const useBlockOperation = ({
 
       // 선택된 텍스트가 없으면 기본 키 핸들러 실행
       if (selection.isCollapsed) {
+        isLocalChange.current = true;
         onKeyDown(e);
         return;
       }
 
       const range = selection.getRangeAt(0);
       if (!blockRef.contains(range.commonAncestorContainer)) return;
-
+      isLocalChange.current = true;
       const startOffset = getTextOffset(blockRef, range.startContainer, range.startOffset);
       const endOffset = getTextOffset(blockRef, range.endContainer, range.endOffset);
 

--- a/client/src/features/editor/hooks/useCopyAndPaste.ts
+++ b/client/src/features/editor/hooks/useCopyAndPaste.ts
@@ -17,9 +17,15 @@ interface UseCopyAndPasteProps {
   editorCRDT: EditorCRDT;
   pageId: string;
   setEditorState: React.Dispatch<React.SetStateAction<EditorStateProps>>;
+  isLocalChange: React.MutableRefObject<boolean>;
 }
 
-export const useCopyAndPaste = ({ editorCRDT, pageId, setEditorState }: UseCopyAndPasteProps) => {
+export const useCopyAndPaste = ({
+  editorCRDT,
+  pageId,
+  setEditorState,
+  isLocalChange,
+}: UseCopyAndPasteProps) => {
   const { sendCharInsertOperation, sendCharDeleteOperation } = useSocketStore();
 
   const handleCopy = useCallback(
@@ -67,10 +73,14 @@ export const useCopyAndPaste = ({ editorCRDT, pageId, setEditorState }: UseCopyA
       if (!blockRef) return;
 
       const selection = window.getSelection();
-
+      isLocalChange.current = true;
       if (selection && !selection.isCollapsed) {
         const range = selection.getRangeAt(0);
-        if (!blockRef.contains(range.commonAncestorContainer)) return;
+        if (!blockRef.contains(range.commonAncestorContainer)) {
+          // ?????
+          isLocalChange.current = false;
+          return;
+        }
 
         const startOffset = getTextOffset(blockRef, range.startContainer, range.startOffset);
         const endOffset = getTextOffset(blockRef, range.endContainer, range.endOffset);

--- a/client/src/features/editor/hooks/useEditorOperation.ts
+++ b/client/src/features/editor/hooks/useEditorOperation.ts
@@ -8,6 +8,8 @@ import {
   RemoteCharUpdateOperation,
   RemoteBlockInsertOperation,
 } from "@noctaCrdt/Interfaces";
+import { TextLinkedList } from "@noctaCrdt/LinkedList";
+import { CharId } from "@noctaCrdt/NodeId";
 import { useCallback } from "react";
 import { useSocketStore } from "@src/stores/useSocketStore";
 import { EditorStateProps } from "../Editor";
@@ -16,12 +18,27 @@ interface UseEditorOperationProps {
   editorCRDT: React.MutableRefObject<EditorCRDT>;
   pageId: string;
   setEditorState: (state: EditorStateProps) => void;
+  isSameLocalChange: React.MutableRefObject<boolean>;
 }
+
+const getPositionById = (linkedList: TextLinkedList, nodeId: CharId | null): number => {
+  if (!nodeId) return 0;
+  let position = 0;
+  let current = linkedList.head;
+
+  while (current) {
+    if (current.equals(nodeId)) return position;
+    position += 1;
+    current = linkedList.getNode(current) ? linkedList.getNode(current)!.next : null;
+  }
+  return position;
+};
 
 export const useEditorOperation = ({
   editorCRDT,
   pageId,
   setEditorState,
+  isSameLocalChange,
 }: UseEditorOperationProps) => {
   const { sendBlockInsertOperation } = useSocketStore();
   const handleRemoteBlockInsert = useCallback(
@@ -59,11 +76,21 @@ export const useEditorOperation = ({
   );
 
   const handleRemoteCharInsert = useCallback(
+    // 원격으로 입력된 글자의 위치가 현재 캐럿의 위치보다 작을때만 캐럿을 1 증가시킨다.
     (operation: RemoteCharInsertOperation) => {
       if (operation.pageId !== pageId) return;
       const targetBlock = editorCRDT.current.LinkedList.nodeMap[JSON.stringify(operation.blockId)];
       if (targetBlock) {
+        if (targetBlock === editorCRDT.current.currentBlock) {
+          isSameLocalChange.current = true;
+          console.log("isSameLocalChange", isSameLocalChange.current);
+        }
+        const insertPosition = getPositionById(targetBlock.crdt.LinkedList, operation.node.prev);
+        const { currentCaret } = targetBlock.crdt;
         targetBlock.crdt.remoteInsert(operation);
+        if (editorCRDT.current.currentBlock === targetBlock && insertPosition < currentCaret) {
+          editorCRDT.current.currentBlock.crdt.currentCaret += 1;
+        }
         setEditorState({
           clock: editorCRDT.current.clock,
           linkedList: editorCRDT.current.LinkedList,
@@ -78,7 +105,15 @@ export const useEditorOperation = ({
       if (operation.pageId !== pageId) return;
       const targetBlock = editorCRDT.current.LinkedList.nodeMap[JSON.stringify(operation.blockId)];
       if (targetBlock) {
+        if (targetBlock === editorCRDT.current.currentBlock) {
+          isSameLocalChange.current = true;
+        }
+        const deletePosition = getPositionById(targetBlock.crdt.LinkedList, operation.targetId);
+        const { currentCaret } = targetBlock.crdt;
         targetBlock.crdt.remoteDelete(operation);
+        if (editorCRDT.current.currentBlock === targetBlock && deletePosition < currentCaret) {
+          editorCRDT.current.currentBlock.crdt.currentCaret -= 1;
+        }
         setEditorState({
           clock: editorCRDT.current.clock,
           linkedList: editorCRDT.current.LinkedList,

--- a/client/src/features/editor/hooks/useTextOptions.ts
+++ b/client/src/features/editor/hooks/useTextOptions.ts
@@ -10,12 +10,14 @@ interface UseTextOptionSelectProps {
   editorCRDT: EditorCRDT;
   setEditorState: React.Dispatch<React.SetStateAction<EditorStateProps>>;
   pageId: string;
+  isLocalChange: React.MutableRefObject<boolean>;
 }
 
 export const useTextOptionSelect = ({
   editorCRDT,
   setEditorState,
   pageId,
+  isLocalChange,
 }: UseTextOptionSelectProps) => {
   const { sendCharUpdateOperation } = useSocketStore();
 
@@ -25,6 +27,7 @@ export const useTextOptionSelect = ({
       const block = editorCRDT.LinkedList.getNode(blockId) as Block;
       if (!block) return;
 
+      isLocalChange.current = true;
       // 선택된 범위의 모든 문자들의 현재 스타일 상태 확인
       const hasStyle = nodes.every((node) => {
         const char = block.crdt.LinkedList.getNode(node.id) as Char;
@@ -82,6 +85,7 @@ export const useTextOptionSelect = ({
       const block = editorCRDT.LinkedList.getNode(blockId) as Block;
       if (!block) return;
 
+      isLocalChange.current = true;
       nodes.forEach((node) => {
         const char = block.crdt.LinkedList.getNode(node.id) as Char;
         if (!char) return;
@@ -114,6 +118,7 @@ export const useTextOptionSelect = ({
       const block = editorCRDT.LinkedList.getNode(blockId) as Block;
       if (!block) return;
 
+      isLocalChange.current = true;
       nodes.forEach((node) => {
         const char = block.crdt.LinkedList.getNode(node.id) as Char;
         if (!char) return;

--- a/client/src/features/editor/utils/domSyncUtils.ts
+++ b/client/src/features/editor/utils/domSyncUtils.ts
@@ -139,7 +139,16 @@ const setsEqual = (a: Set<string>, b: Set<string>): boolean => {
 };
 
 const sanitizeText = (text: string): string => {
-  return text.replace(/<br>/g, "\u00A0");
+  return text.replace(/<br>/g, "\u00A0").replace(/[<>&"']/g, (match) => {
+    const escapeMap: Record<string, string> = {
+      "<": "&lt;",
+      ">": "&gt;",
+      "&": "&amp;",
+      '"': "&quot;",
+      "'": "&#x27;",
+    };
+    return escapeMap[match] || match;
+  });
 };
 
 // 배열 비교 헬퍼 함수

--- a/server/src/crdt/crdt.gateway.ts
+++ b/server/src/crdt/crdt.gateway.ts
@@ -537,15 +537,16 @@ export class CrdtGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
       }
       currentBlock.crdt.remoteInsert(data);
 
+      console.log("data", data);
       // server는 EditorCRDT 없습니다. - BlockCRDT 로 사용되고있음.
       const operation = {
         type: "charInsert",
         node: data.node,
         blockId: data.blockId,
         pageId: data.pageId,
-        style: data.style || [],
-        color: data.color ? data.color : "black",
-        backgroundColor: data.backgroundColor ? data.backgroundColor : "transparent",
+        style: data.node.style || [],
+        color: data.node.color ? data.node.color : "black",
+        backgroundColor: data.node.backgroundColor ? data.node.backgroundColor : "transparent",
       } as RemoteCharInsertOperation;
       this.emitOperation(client.id, data.pageId, "insert/char", operation, batch);
     } catch (error) {


### PR DESCRIPTION
## 📝 변경 사항

- #248

## 🔍 변경 사항 설명

현재 한번 에러가 나면 해당 블록과 에디터의 `모든` 연산이 꼬이게 되어서 해당 블록을 지우지 않는 이상 계속 에러가 나는 것 같습니다. 서버에 잘못된 연결 상태나 노드가 들어가게 되면서 해당 내용을 기반으로 연산을 처리하다보니 계속 문제가 발생하는 것 같습니다. 조금 조심(?)해서 입력하면 아직 문제되는 건 없었습니다. 

`해결한 내용`
- 여러 페이지를 열었을 때, 캐럿이 다른 페이지로 튀는 문제
- 같은 블록을 여러사람이 입력할 경우 캐럿이 이상하게 튀는 문제

## 🙏 질문 사항

`아직 수정이 필요한 내용`
- 같은 블록의 같은 위치(동일한 clock)에 동시에 연산이 들어올 경우 해당 부분에 이상하게 노드가 저장되는 문제
  1. NodeId 속성에 timestamp 속성을 추가한 후 두 연산이 clock이 동일한 경우 timestamp값을 확인해 더 빨리 입력된 노드를 앞에 저장합니다
  2. 동일한 clock 연산이 들어왔을 경우 client의 숫자가 작은 연산을 먼저 입력합니다. 이 경우 저희가 지정한 규칙에 따라 동시 연산을 처리합니다.

1번 방법의 경우 기존 crdt 로직을 수정해야 하다보니까 혼자 하기에는 무리가 있는 것 같아 아직 수정하지 않았습니다. 혹시 이부분에 대해서 의견 있으시면 말씀해 주세요!

## 📷 스크린샷 (선택)

### 여러 페이지에서 입력이 올때 이상한 페이지로 캐럿이 튀는 문제 해결
https://github.com/user-attachments/assets/a1d4fe50-646a-4c69-b1dd-23c07c1a2c31

### 같은 블록에 여러명이 입력할 때 캐럿이 튀는 문제 해결
맥에서 먼저 asdf를 입력하고, 이후에 pc에서 asdf를 입력했습니다.

https://github.com/user-attachments/assets/3fd61e24-69ab-4970-a25a-613e0167b79e



## ✅ 작성자 체크리스트

- [x] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [x] 로컬에서 모든 기능이 정상 작동함
- [x] 린터 및 포맷터로 코드 정리됨
- [ ] 의존성 업데이트 확인
- [x] 문서 업데이트 또는 주석 추가 (필요 시)
