### PR TITLE
Feature/#253 온보딩 오버레이 추가

### DIFF
--- a/client/src/components/bottomNavigator/BottomNavigator.tsx
+++ b/client/src/components/bottomNavigator/BottomNavigator.tsx
@@ -7,11 +7,16 @@ import { bottomNavigatorContainer } from "./BottomNavigator.style";
 interface BottomNavigatorProps {
   pages: Page[];
   handlePageSelect: ({ pageId, isSidebar }: { pageId: string; isSidebar?: boolean }) => void;
+  BottomNavigatorOnBoardingProps?: Record<string, string>;
 }
 
-export const BottomNavigator = ({ pages, handlePageSelect }: BottomNavigatorProps) => {
+export const BottomNavigator = ({
+  pages,
+  handlePageSelect,
+  BottomNavigatorOnBoardingProps,
+}: BottomNavigatorProps) => {
   return (
-    <div className={bottomNavigatorContainer}>
+    <div className={bottomNavigatorContainer} {...BottomNavigatorOnBoardingProps}>
       {pages.map((page) => (
         <motion.div
           key={page.id}

--- a/client/src/components/button/IconButton.tsx
+++ b/client/src/components/button/IconButton.tsx
@@ -12,7 +12,11 @@ export const IconButton = ({ icon, size, onClick }: IconButtonProps) => {
   const { icon: IconComponent, color: defaultColor }: IconConfig = iconComponents[icon];
 
   return (
-    <button className={iconButtonContainer({ size })} onClick={onClick}>
+    <button
+      className={iconButtonContainer({ size })}
+      data-onboarding="page-add-button"
+      onClick={onClick}
+    >
       <IconComponent color={defaultColor} size="24px" />
     </button>
   );

--- a/client/src/components/button/textButton.tsx
+++ b/client/src/components/button/textButton.tsx
@@ -8,7 +8,11 @@ interface TextButtonProps {
 
 export const TextButton = ({ variant = "primary", children, onClick }: TextButtonProps) => {
   return (
-    <button className={textButtonContainer({ variant })} onClick={onClick}>
+    <button
+      className={textButtonContainer({ variant })}
+      onClick={onClick}
+      data-onboarding="login-button"
+    >
       {children}
     </button>
   );

--- a/client/src/components/sidebar/Sidebar.tsx
+++ b/client/src/components/sidebar/Sidebar.tsx
@@ -25,6 +25,7 @@ export const Sidebar = ({
   handlePageAdd,
   handlePageOpen,
   handlePageUpdate,
+  sidebarOnBoardingProps,
 }: {
   pages: Page[];
   handlePageAdd: () => void;
@@ -34,6 +35,7 @@ export const Sidebar = ({
     updates: { title?: string; icon?: PageIconType },
     syncWithServer: boolean,
   ) => void;
+  sidebarOnBoardingProps?: Record<string, string>;
 }) => {
   const visiblePages = pages.filter((page) => page.isVisible && page.isLoaded);
   const isMaxVisiblePage = visiblePages.length > MAX_VISIBLE_PAGE;
@@ -41,7 +43,6 @@ export const Sidebar = ({
   const { toggleSidebar } = useSidebarActions();
   const { isOpen, openModal, closeModal } = useModal();
   const { sendPageDeleteOperation, clientId } = useSocketStore();
-
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [pageToDelete, setPageToDelete] = useState<Page | null>(null);
 
@@ -87,6 +88,7 @@ export const Sidebar = ({
       initial="open"
       animate={isSidebarOpen ? "open" : "closed"}
       variants={sidebarVariants}
+      {...sidebarOnBoardingProps}
     >
       <div className={sidebarToggleButton} onClick={toggleSidebar}>
         {isSidebarOpen ? "«" : "»"}

--- a/client/src/components/sidebar/components/menuButton/MenuButton.tsx
+++ b/client/src/components/sidebar/components/menuButton/MenuButton.tsx
@@ -29,7 +29,11 @@ export const MenuButton = () => {
   }, []);
 
   return (
-    <button className={`${menuButtonContainer} menu_button_container`} onClick={handleMenuClick}>
+    <button
+      className={`${menuButtonContainer} menu_button_container`}
+      onClick={handleMenuClick}
+      data-onboarding="menu-button"
+    >
       <button className={menuItemWrapper}>
         <MenuIcon />
         <p className={textBox}>{name ?? "Nocta"}</p>

--- a/client/src/features/auth/AuthButton.tsx
+++ b/client/src/features/auth/AuthButton.tsx
@@ -1,8 +1,8 @@
 import { useLogoutMutation } from "@apis/auth";
-import { useCheckLogin } from "@stores/useUserStore";
 import { TextButton } from "@components/button/textButton";
 import { Modal } from "@components/modal/modal";
 import { useModal } from "@components/modal/useModal";
+import { useCheckLogin } from "@stores/useUserStore";
 import { AuthModal } from "./AuthModal";
 
 export const AuthButton = () => {

--- a/client/src/features/workSpace/WorkSpace.tsx
+++ b/client/src/features/workSpace/WorkSpace.tsx
@@ -9,6 +9,7 @@ import { ToastContainer } from "@src/components/Toast/ToastContainer";
 import { useSocketStore } from "@src/stores/useSocketStore";
 import { workSpaceContainer, content } from "./WorkSpace.style";
 import { IntroScreen } from "./components/IntroScreen";
+import { OnboardingOverlay } from "./components/OnboardingOverlay";
 import { usePagesManage } from "./hooks/usePagesManage";
 import { useWorkspaceInit } from "./hooks/useWorkspaceInit";
 
@@ -16,6 +17,7 @@ export const WorkSpace = () => {
   const [workspace, setWorkspace] = useState<WorkSpaceClass | null>(null);
   const { isLoading, isInitialized, error } = useWorkspaceInit();
   const { workspace: workspaceMetadata, clientId } = useSocketStore();
+  const [showOnboarding, setShowOnboarding] = useState(false);
 
   const {
     pages,
@@ -44,6 +46,16 @@ export const WorkSpace = () => {
     }
   }, [workspaceMetadata]);
 
+  useEffect(() => {
+    // IntroScreen이 끝나고 초기화가 완료된 후에 지연시켜서 온보딩 표시
+    if (!isLoading && isInitialized) {
+      // 약간의 딜레이를 주어 UI가 완전히 렌더링된 후에 온보딩 표시
+      setTimeout(() => {
+        setShowOnboarding(true);
+      }, 500); // 500ms 딜레이
+    }
+  }, [isLoading, isInitialized]);
+
   if (error) {
     return <ErrorModal errorMessage="서버와 연결할 수 없습니다." />;
   }
@@ -52,6 +64,7 @@ export const WorkSpace = () => {
     <>
       <ToastContainer />
       <AnimatePresence mode="wait">{isLoading && <IntroScreen />}</AnimatePresence>
+
       <div
         className={workSpaceContainer({
           visibility: isInitialized && !isLoading ? "visible" : "hidden",
@@ -59,6 +72,9 @@ export const WorkSpace = () => {
         })}
       >
         <Sidebar
+          sidebarOnBoardingProps={{
+            "data-onboarding": "sidebar",
+          }}
           pages={pages}
           handlePageAdd={fetchPage}
           handlePageOpen={openPage}
@@ -75,8 +91,16 @@ export const WorkSpace = () => {
             />
           ))}
         </div>
-        <BottomNavigator pages={visiblePages} handlePageSelect={openPage} />
+        <BottomNavigator
+          BottomNavigatorOnBoardingProps={{
+            "data-onboarding": "bottom-nav",
+          }}
+          pages={visiblePages}
+          data-onboarding="bottom-nav"
+          handlePageSelect={openPage}
+        />
       </div>
+      {<OnboardingOverlay isShow={showOnboarding} />}
     </>
   );
 };

--- a/client/src/features/workSpace/components/OnboardingOverlay.style.ts
+++ b/client/src/features/workSpace/components/OnboardingOverlay.style.ts
@@ -1,0 +1,90 @@
+import { css, cva } from "@styled-system/css";
+
+export const overlayContainer = css({
+  zIndex: 9999,
+  position: "fixed",
+  inset: 0,
+});
+
+export const highlightBox = css({
+  position: "absolute",
+  borderColor: "rgba(168, 85, 247, 0.5)", // purple-400 with 50% opacity
+  borderRadius: "xl",
+  borderWidth: "2px",
+  backgroundColor: "rgba(255, 255, 255, 0.1)",
+  pointerEvents: "none",
+});
+
+export const tooltipBox = css({
+  zIndex: 10000,
+  position: "absolute",
+  borderRadius: "xl",
+  width: "280px",
+  padding: "4",
+  backgroundColor: "rgba(255, 255, 255, 0.9)",
+  boxShadow: "xl",
+  backdropFilter: "blur(4px)",
+});
+
+export const tooltipTitle = css({
+  marginBottom: "2",
+  color: "purple.900",
+  fontSize: "lg",
+  fontWeight: "semibold",
+});
+
+export const tooltipDescription = css({
+  marginBottom: "4",
+  color: "gray.600",
+});
+
+export const IndicatorContainer = css({ display: "flex", gap: "2px" });
+export const stepIndicator = cva({
+  base: {
+    borderRadius: "full",
+    width: "5px",
+    height: "5px",
+    transition: "colors",
+  },
+  variants: {
+    active: {
+      true: {
+        backgroundColor: "purple.500",
+      },
+      false: {
+        backgroundColor: "gray.300",
+      },
+    },
+  },
+});
+
+export const nextButton = cva({
+  base: {
+    borderRadius: "lg",
+    paddingY: "1.5",
+    paddingX: "4",
+    fontSize: "sm",
+    transition: "colors",
+  },
+  variants: {
+    variant: {
+      primary: {
+        color: "white",
+        backgroundColor: "purple.500",
+        _hover: {
+          backgroundColor: "purple.600",
+        },
+      },
+      secondary: {
+        color: "gray.700",
+        backgroundColor: "gray.100",
+        _hover: {
+          backgroundColor: "gray.200",
+        },
+      },
+    },
+  },
+  defaultVariants: {
+    variant: "primary",
+  },
+});

--- a/client/src/features/workSpace/components/OnboardingOverlay.tsx
+++ b/client/src/features/workSpace/components/OnboardingOverlay.tsx
@@ -58,13 +58,6 @@ export const OnboardingOverlay = ({ isShow }: OnboardingOverlayProps) => {
       description: "열려있는 페이지들을 쉽게 전환할 수 있어요.",
       position: "top",
     },
-
-    {
-      target: '[data-onboarding="login-button"]',
-      title: "로그인 버튼",
-      description: "로그인 하여 나만의 워크스페이스를 관리할 수 있어요.",
-      position: "top",
-    },
   ];
   useEffect(() => {
     const hasCompletedOnboarding = sessionStorage.getItem("hasCompletedOnboarding");

--- a/client/src/features/workSpace/components/OnboardingOverlay.tsx
+++ b/client/src/features/workSpace/components/OnboardingOverlay.tsx
@@ -1,0 +1,199 @@
+import { motion } from "framer-motion";
+import { useState, useEffect } from "react";
+import {
+  overlayContainer,
+  highlightBox,
+  tooltipBox,
+  tooltipTitle,
+  tooltipDescription,
+  stepIndicator,
+  nextButton,
+  IndicatorContainer,
+} from "./OnboardingOverlay.style";
+
+type Position = "right" | "left" | "top" | "bottom";
+type Step = {
+  target: string;
+  title: string;
+  description: string;
+  position: Position;
+};
+
+interface OnboardingOverlayProps {
+  isShow: boolean;
+}
+
+export const OnboardingOverlay = ({ isShow }: OnboardingOverlayProps) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const [currentStep, setCurrentStep] = useState(0);
+
+  const steps: Step[] = [
+    {
+      target: '[data-onboarding="menu-button"]',
+      title: "메인 워크스페이스",
+      description: "여러 페이지를 동시에 열고 자유롭게 작업할 수 있어요.",
+      position: "right",
+    },
+    {
+      target: '[data-onboarding="sidebar"]',
+      title: "사이드바",
+      description: "현재 워크스페이스에서 새로운 페이지를 만들고 관리할 수 있어요.",
+      position: "right",
+    },
+    {
+      target: '[data-onboarding="page-add-button"]',
+      title: "페이지 추가 버튼",
+      description: "새로운 페이지를 추가할 수 있어요.",
+      position: "top",
+    },
+    {
+      target: '[data-onboarding="login-button"]',
+      title: "로그인 버튼",
+      description: "로그인 하여 나만의 워크스페이스를 관리할 수 있어요.",
+      position: "top",
+    },
+    {
+      target: '[data-onboarding="bottom-nav"]',
+      title: "하단 네비게이터",
+      description: "열려있는 페이지들을 쉽게 전환할 수 있어요.",
+      position: "top",
+    },
+
+    {
+      target: '[data-onboarding="login-button"]',
+      title: "로그인 버튼",
+      description: "로그인 하여 나만의 워크스페이스를 관리할 수 있어요.",
+      position: "top",
+    },
+  ];
+  useEffect(() => {
+    const hasCompletedOnboarding = sessionStorage.getItem("hasCompletedOnboarding");
+
+    if (isShow && hasCompletedOnboarding === null) {
+      // 요소들이 렌더링될 시간을 주기 위해 약간의 딜레이 추가
+      const timer = setTimeout(() => {
+        setIsVisible(true);
+      }, 100);
+
+      return () => clearTimeout(timer);
+    }
+  }, [isShow]);
+
+  useEffect(() => {
+    console.log("Onboarding state:", { isShow, isVisible, currentStep });
+  }, [isShow, isVisible, currentStep]);
+
+  const handleClose = () => {
+    if (currentStep < steps.length - 1) {
+      setCurrentStep((prev) => prev + 1);
+    } else {
+      setIsVisible(false);
+      sessionStorage.setItem("hasCompletedOnboarding", "true");
+    }
+  };
+  const handlePrevious = () => {
+    if (currentStep > 0) {
+      setCurrentStep((prev) => prev - 1);
+    }
+  };
+  const getTargetPosition = (selector: string) => {
+    const element = document.querySelector(selector);
+    if (!element) {
+      console.log(`Element not found: ${selector}`);
+      return null;
+    }
+
+    const rect = element.getBoundingClientRect();
+    return {
+      left: rect.left,
+      top: rect.top,
+      width: rect.width,
+      height: rect.height,
+    };
+  };
+  const getTooltipPosition = (step: Step) => {
+    const targetRect = document.querySelector(step.target)?.getBoundingClientRect();
+    if (!targetRect) return null;
+
+    const positions: Record<Position, { top: number; left: number }> = {
+      right: {
+        left: targetRect.right + 16,
+        top: targetRect.top + targetRect.height / 2 - 60,
+      },
+      left: {
+        left: targetRect.left - 280,
+        top: targetRect.top + targetRect.height / 2 - 60,
+      },
+      top: {
+        left: targetRect.left + targetRect.width / 2 + 40,
+        top: targetRect.top - 150,
+      },
+      bottom: {
+        left: targetRect.left + targetRect.width / 2 - 140,
+        top: targetRect.bottom + 16,
+      },
+    };
+
+    return positions[step.position];
+  };
+
+  if (!isVisible) return null;
+
+  const currentStepData = steps[currentStep];
+  const targetPosition = getTargetPosition(currentStepData.target);
+  const tooltipPosition = getTooltipPosition(currentStepData);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      className={overlayContainer}
+    >
+      {targetPosition && (
+        <motion.div
+          className={highlightBox}
+          style={{
+            left: targetPosition.left,
+            top: targetPosition.top,
+            width: targetPosition.width,
+            height: targetPosition.height,
+            transition: "all 0.3s ease",
+          }}
+        />
+      )}
+
+      {tooltipPosition && (
+        <motion.div
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          className={tooltipBox}
+          style={{
+            left: tooltipPosition.left,
+            top: tooltipPosition.top,
+          }}
+        >
+          <div className={IndicatorContainer}>
+            {steps.map((_, index) => (
+              <div key={index} className={stepIndicator({ active: index === currentStep })} />
+            ))}
+          </div>
+          <h3 className={tooltipTitle}>{currentStepData.title}</h3>
+          <p className={tooltipDescription}>{currentStepData.description}</p>
+          <div className="flex justify-between items-center">
+            <div className="flex gap-2">
+              {currentStep > 0 && (
+                <button onClick={handlePrevious} className={nextButton({ variant: "secondary" })}>
+                  이전
+                </button>
+              )}
+              <button onClick={handleClose} className={nextButton({ variant: "primary" })}>
+                {currentStep === steps.length - 1 ? "시작하기" : "다음"}
+              </button>
+            </div>
+          </div>
+        </motion.div>
+      )}
+    </motion.div>
+  );
+};


### PR DESCRIPTION
## 📝 변경 사항

https://github.com/user-attachments/assets/3642cabb-b466-4530-b26c-6f67edd466b8


- 온보딩 오버레이를 추가했습니다.

## 🔍 변경 사항 설명

- 온보딩오버레이가 추적하기 위해 sideBar나 페이지 추가버튼, loginButton 에 `data-onBoarding` props를 추가했습니다.

## 🙏 질문 사항

- [ ] 피드백 의견 자유롭게 받습니다!!
- [ ] 튜토리얼 처럼 페이지를 만들어보세요 이런걸 할까 했는데, 처음 진입하는 화면이 게스트라 페이지가 이미 있을 수도 있어서 지금은 빼버렸습니다.

## 📷 스크린샷 (선택)

- UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

## ✅ 작성자 체크리스트

- [x] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [x] 로컬에서 모든 기능이 정상 작동함
- [x] 린터 및 포맷터로 코드 정리됨
- [x] 의존성 업데이트 확인
- [ ] 문서 업데이트 또는 주석 추가 (필요 시)
