### PR TITLE
Hotfix/#252 블록에 한글 첫입력시 캐럿 튀는문제

### DIFF
--- a/client/src/features/editor/Editor.tsx
+++ b/client/src/features/editor/Editor.tsx
@@ -182,14 +182,14 @@ export const Editor = ({ onTitleChange, pageId, pageTitle, serializedEditorData 
       const event = e.nativeEvent as CompositionEvent;
       const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
 
-      if (!composingCaret.current) return;
+      if (composingCaret.current === null) return;
       const currentCaret = composingCaret.current;
       const currentCharNode = block.crdt.LinkedList.findByIndex(currentCaret);
       if (!currentCharNode) return;
 
       if (isMac) {
         const [character, space] = event.data;
-        if (!character || !composingCaret.current) return;
+        if (!character || composingCaret.current === null) return;
         if (!currentCharNode) return;
         currentCharNode.value = character;
         sendCharInsertOperation({
@@ -226,6 +226,9 @@ export const Editor = ({ onTitleChange, pageId, pageTitle, serializedEditorData 
       }
 
       composingCaret.current = null;
+      if (isSameLocalChange.current) {
+        isSameLocalChange.current = false;
+      }
     },
     [editorCRDT, pageId, sendCharInsertOperation],
   );
@@ -247,7 +250,12 @@ export const Editor = ({ onTitleChange, pageId, pageTitle, serializedEditorData 
         pageId,
       });
       isLocalChange.current = false;
-      isSameLocalChange.current = false;
+      if (composingCaret.current !== null) {
+        isSameLocalChange.current = true;
+      } else {
+        isSameLocalChange.current = false;
+      }
+
       return;
     }
     // 서윤님 피드백 반영

--- a/client/src/features/editor/hooks/useBlockOperation.ts
+++ b/client/src/features/editor/hooks/useBlockOperation.ts
@@ -83,7 +83,7 @@ export const useBlockOperation = ({
               currentContent.length - 1,
             );
           }
-          console.log("prevChar", prevChar);
+
           const addedChar = newContent[newContent.length - 1];
           charNode = block.crdt.localInsert(
             currentContent.length,


### PR DESCRIPTION
## 📝 변경 사항

- 블록에 한글 첫입력시 서버에서 에러가 나는 문제

## 🔍 변경 사항 설명

- composingCaret.current가 number로 관리가 되는데 분기 처리를 할 때 0인 경우 falsy한 값으로 처리가 되어 !composingCaret.current가 true가 되는 문제가 있었습니다

## 🙏 질문 사항

## 📷 스크린샷 (선택)

- UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

## ✅ 작성자 체크리스트

- [x] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [x] 로컬에서 모든 기능이 정상 작동함
- [x] 린터 및 포맷터로 코드 정리됨
- [ ] 의존성 업데이트 확인
- [ ] 문서 업데이트 또는 주석 추가 (필요 시)
