### PR TITLE
Feature/#269 workspace 관련 완성도 개선

### DIFF
--- a/client/src/assets/icons/pencil.svg
+++ b/client/src/assets/icons/pencil.svg
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" height="800px" width="800px" version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 306.637 306.637" xml:space="preserve">
+<g>
+	<g>
+		<path d="M12.809,238.52L0,306.637l68.118-12.809l184.277-184.277l-55.309-55.309L12.809,238.52z M60.79,279.943l-41.992,7.896
+			l7.896-41.992L197.086,75.455l34.096,34.096L60.79,279.943z"/>
+		<path d="M251.329,0l-41.507,41.507l55.308,55.308l41.507-41.507L251.329,0z M231.035,41.507l20.294-20.294l34.095,34.095
+			L265.13,75.602L231.035,41.507z"/>
+	</g>
+	<g>
+	</g>
+	<g>
+	</g>
+	<g>
+	</g>
+	<g>
+	</g>
+	<g>
+	</g>
+	<g>
+	</g>
+	<g>
+	</g>
+	<g>
+	</g>
+	<g>
+	</g>
+	<g>
+	</g>
+	<g>
+	</g>
+	<g>
+	</g>
+	<g>
+	</g>
+	<g>
+	</g>
+	<g>
+	</g>
+</g>
+</svg>

--- a/client/src/components/modal/RenameModal.style.ts
+++ b/client/src/components/modal/RenameModal.style.ts
@@ -1,0 +1,29 @@
+import { css } from "@styled-system/css";
+
+export const container = css({
+  display: "flex",
+  gap: "4",
+  flexDirection: "column",
+});
+
+export const title = css({
+  color: "gray.700",
+  fontSize: "lg",
+  fontWeight: "medium",
+});
+
+export const input = css({
+  borderColor: "gray.200",
+  borderRadius: "md",
+  borderWidth: "1px",
+  width: "full",
+  paddingY: "2",
+  paddingX: "3",
+  _focus: {
+    outline: "none",
+    borderColor: "blue.500",
+  },
+  _hover: {
+    borderColor: "gray.300",
+  },
+});

--- a/client/src/components/modal/RenameModal.tsx
+++ b/client/src/components/modal/RenameModal.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import { container, title, input } from "./RenameModal.style";
+import { Modal } from "./modal";
+
+interface RenameModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onRename: (newName: string) => void;
+  currentName: string;
+}
+
+export const RenameModal = ({ isOpen, onClose, onRename, currentName }: RenameModalProps) => {
+  const [name, setName] = useState(currentName);
+
+  const handleRename = () => {
+    if (name.trim()) {
+      onRename(name);
+      onClose();
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      primaryButtonLabel="변경하기"
+      primaryButtonOnClick={handleRename}
+      secondaryButtonLabel="취소"
+      secondaryButtonOnClick={onClose}
+    >
+      <div className={container}>
+        <h2 className={title}>워크스페이스 이름 변경</h2>
+        <input
+          className={input}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="새로운 워크스페이스 이름"
+        />
+      </div>
+    </Modal>
+  );
+};

--- a/client/src/components/sidebar/components/menuButton/MenuButton.style.ts
+++ b/client/src/components/sidebar/components/menuButton/MenuButton.style.ts
@@ -2,7 +2,7 @@ import { css } from "@styled-system/css";
 
 export const menuItemWrapper = css({
   display: "flex",
-  gap: "md",
+  gap: "32px",
   alignItems: "center",
   width: "250px",
   padding: "md",
@@ -15,6 +15,7 @@ export const menuItemWrapper = css({
 export const textBox = css({
   color: "gray.700",
   fontSize: "md",
+  fontWeight: "medium",
 });
 
 export const menuButtonContainer = css({
@@ -24,7 +25,48 @@ export const menuButtonContainer = css({
     top: "100%",
     left: 0,
     width: "100%",
-    height: "4px", // top: calc(100% + 4px)와 동일한 값
+    height: "4px",
     content: '""',
   },
+});
+
+export const nameWrapper = css({
+  display: "flex",
+  gap: "1",
+  flexDirection: "column",
+  borderColor: "gray.200",
+  borderRadius: "md",
+  borderWidth: "1px",
+  padding: "sm",
+  borderStyle: "solid",
+  _hover: {
+    borderColor: "gray.300", // hover 시 테두리 색상 변경
+  },
+});
+export const workspaceInfo = css({
+  display: "flex",
+  gap: "0.5",
+  flexDirection: "column",
+});
+
+export const workspaceHeader = css({
+  display: "flex",
+  gap: "2",
+  alignItems: "center",
+});
+
+export const currentWorkspaceNameBox = css({
+  color: "gray.600",
+  fontSize: "sm",
+  fontWeight: "medium",
+});
+
+export const workspaceRole = css({
+  color: "gray.500",
+  fontSize: "xs",
+});
+
+export const userCount = css({
+  color: "gray.500",
+  fontSize: "xs",
 });

--- a/client/src/components/sidebar/components/menuButton/MenuButton.tsx
+++ b/client/src/components/sidebar/components/menuButton/MenuButton.tsx
@@ -5,7 +5,16 @@ import { useSocketStore } from "@src/stores/useSocketStore";
 import { useToastStore } from "@src/stores/useToastStore";
 import { useWorkspaceStore } from "@src/stores/useWorkspaceStore";
 import { useUserInfo } from "@stores/useUserStore";
-import { menuItemWrapper, textBox, menuButtonContainer } from "./MenuButton.style";
+import {
+  menuItemWrapper,
+  textBox,
+  menuButtonContainer,
+  // userCount,
+  // currentWorkspaceNameBox,
+  // workspaceInfo,
+  // workspaceRole,
+  // nameWrapper,
+} from "./MenuButton.style";
 import { MenuIcon } from "./components/MenuIcon";
 import { WorkspaceSelectModal } from "./components/WorkspaceSelectModal";
 
@@ -14,12 +23,15 @@ export const MenuButton = () => {
   const [isOpen, setIsOpen] = useState(false);
   const { socket, workspace } = useSocketStore();
   const { addToast } = useToastStore();
+  const currentRole = useWorkspaceStore((state) => state.currentRole);
+  // const currentWorkspaceName = useWorkspaceStore((state) => state.currentWorkspaceName);
+  // const currentActiveUsers = useWorkspaceStore((state) => state.currentActiveUsers);
+  // const currentMemberCount = useWorkspaceStore((state) => state.currentMemberCount);
   const {
     isOpen: isInviteModalOpen,
     openModal: openInviteModal,
     closeModal: closeInviteModal,
   } = useModal();
-  const currentRole = useWorkspaceStore((state) => state.currentRole);
   const handleMenuClick = () => {
     setIsOpen((prev) => !prev);
   };
@@ -91,6 +103,7 @@ export const MenuButton = () => {
     }
     openInviteModal();
   };
+
   return (
     <>
       <button
@@ -101,6 +114,14 @@ export const MenuButton = () => {
         <button className={menuItemWrapper}>
           <MenuIcon />
           <p className={textBox}>{name ?? "Nocta"}</p>
+          {/* <div className={nameWrapper}>
+            {currentWorkspaceName && currentRole && (
+              <div className={workspaceInfo}>
+                <span className={currentWorkspaceNameBox}>{currentWorkspaceName}</span>
+                <span className={workspaceRole}>{currentRole}</span>
+              </div>
+            )}
+          </div> */}
         </button>
         <WorkspaceSelectModal isOpen={isOpen} userName={name} onInviteClick={handleInviteModal} />
         <InviteModal

--- a/client/src/components/sidebar/components/menuButton/components/components/WorkspaceSelectItem.style.tsx
+++ b/client/src/components/sidebar/components/menuButton/components/components/WorkspaceSelectItem.style.tsx
@@ -3,6 +3,7 @@ import { css } from "@styled-system/css";
 
 export const itemContainer = css({
   display: "flex",
+  position: "relative", // 부모 요소에 relative 추가
   justifyContent: "space-between",
   alignItems: "center",
   borderLeft: "3px solid transparent", // 활성화되지 않았을 때 border 공간 확보
@@ -22,9 +23,10 @@ export const informBox = css({
 });
 export const pencilButton = css({
   display: "flex",
-  position: "relative",
-  top: "-40px",
-  left: "225px",
+  position: "absolute", // relative 대신 absolute 사용
+  top: "50%", // 중앙 정렬을 위해
+  right: "5%", // left 대신 right 사용
+  transform: "translateY(-50%)", // 정확한 세로 중앙 정렬
   justifyContent: "center",
   alignItems: "center",
   borderRadius: "6px",

--- a/client/src/components/sidebar/components/menuButton/components/components/WorkspaceSelectItem.style.tsx
+++ b/client/src/components/sidebar/components/menuButton/components/components/WorkspaceSelectItem.style.tsx
@@ -20,10 +20,35 @@ export const informBox = css({
   alignItems: "center",
   marginLeft: "14px",
 });
+export const pencilButton = css({
+  display: "flex",
+  position: "relative",
+  top: "-40px",
+  left: "225px",
+  justifyContent: "center",
+  alignItems: "center",
+  borderRadius: "6px",
+  padding: "1",
+  opacity: "0",
+  backgroundColor: "gray.200",
+  transition: "all",
+  _hover: {
+    backgroundColor: "gray.100",
+  },
+  _groupHover: {
+    opacity: "100",
+  },
+  "& svg": {
+    // SVG 스타일 추가
+    width: "4",
+    height: "4",
+    color: "green",
+  },
+});
 export const itemContent = css({
   display: "flex",
   flex: 1,
-  gap: "10",
+  gap: "4",
   alignItems: "center",
 });
 

--- a/client/src/components/sidebar/components/menuButton/components/components/WorkspaceSelectItem.tsx
+++ b/client/src/components/sidebar/components/menuButton/components/components/WorkspaceSelectItem.tsx
@@ -70,17 +70,18 @@ export const WorkspaceSelectItem = ({
               )}
             </div>
           </div>
+          {isOwner && (
+            <button
+              onClick={() => setIsRenameModalOpen(true)}
+              className={pencilButton}
+              aria-label="워크스페이스 이름 변경"
+            >
+              <PencilIcon />
+            </button>
+          )}
         </div>
       </button>
-      {isOwner && (
-        <button
-          onClick={() => setIsRenameModalOpen(true)}
-          className={pencilButton}
-          aria-label="워크스페이스 이름 변경"
-        >
-          <PencilIcon />
-        </button>
-      )}
+
       <RenameModal
         isOpen={isRenameModalOpen}
         onClose={() => setIsRenameModalOpen(false)}

--- a/client/src/components/sidebar/components/menuButton/components/components/WorkspaceSelectItem.tsx
+++ b/client/src/components/sidebar/components/menuButton/components/components/WorkspaceSelectItem.tsx
@@ -30,11 +30,13 @@ export const WorkspaceSelectItem = ({
   const { workspace, switchWorkspace } = useSocketStore();
   const { addToast } = useToastStore();
   const setCurrentRole = useWorkspaceStore((state) => state.setCurrentRole);
+  const setCurrentWorkspaceName = useWorkspaceStore((state) => state.setCurrentWorkspaceName);
   const isActive = workspace?.id === id; // 현재 워크스페이스 확인
   const handleClick = () => {
     if (!isActive) {
       switchWorkspace(userId, id);
       setCurrentRole(role);
+      setCurrentWorkspaceName(name);
       addToast(`워크스페이스(${name})에 접속하였습니다.`);
     }
   };

--- a/client/src/components/sidebar/components/menuButton/components/components/WorkspaceSelectItem.tsx
+++ b/client/src/components/sidebar/components/menuButton/components/components/WorkspaceSelectItem.tsx
@@ -1,9 +1,13 @@
 import { WorkspaceListItem } from "@noctaCrdt/Interfaces"; // 이전에 만든 인터페이스 import
+import { useState } from "react";
+import PencilIcon from "@assets/icons/pencil.svg?react";
+import { RenameModal } from "@src/components/modal/RenameModal";
 import { useSocketStore } from "@src/stores/useSocketStore";
 import { useToastStore } from "@src/stores/useToastStore";
 import { useUserInfo } from "@src/stores/useUserStore";
 import { useWorkspaceStore } from "@src/stores/useWorkspaceStore";
 import {
+  pencilButton,
   itemContainer,
   itemContent,
   itemIcon,
@@ -30,8 +34,11 @@ export const WorkspaceSelectItem = ({
   const { workspace, switchWorkspace } = useSocketStore();
   const { addToast } = useToastStore();
   const setCurrentRole = useWorkspaceStore((state) => state.setCurrentRole);
+  const [isRenameModalOpen, setIsRenameModalOpen] = useState(false);
+  const { socket } = useSocketStore();
   const setCurrentWorkspaceName = useWorkspaceStore((state) => state.setCurrentWorkspaceName);
   const isActive = workspace?.id === id; // 현재 워크스페이스 확인
+  const isOwner = role === "owner";
   const handleClick = () => {
     if (!isActive) {
       switchWorkspace(userId, id);
@@ -40,23 +47,46 @@ export const WorkspaceSelectItem = ({
       addToast(`워크스페이스(${name})에 접속하였습니다.`);
     }
   };
+  const handleRename = (newName: string) => {
+    socket?.emit("workspace/rename", {
+      workspaceId: id,
+      newName,
+    });
+  };
 
   return (
-    <button className={`${itemContainer} ${isActive ? activeItem : ""}`} onClick={handleClick}>
-      <div className={itemContent}>
-        <div className={itemIcon}>{name.charAt(0)}</div>
-        <div className={itemInfo}>
-          <span className={itemName}>{name}</span>
-          <div className={informBox}>
-            <span className={itemMemberCount}>{role}</span>
-            {memberCount !== undefined && (
-              <span className={itemRole}>
-                접속자수 {activeUsers} / {memberCount} 명{" "}
-              </span>
-            )}
+    <div className="relative flex items-center group">
+      <button className={`${itemContainer} ${isActive ? activeItem : ""}`} onClick={handleClick}>
+        <div className={itemContent}>
+          <div className={itemIcon}>{name.charAt(0)}</div>
+          <div className={itemInfo}>
+            <span className={itemName}>{name}</span>
+            <div className={informBox}>
+              <span className={itemMemberCount}>{role}</span>
+              {memberCount !== undefined && (
+                <span className={itemRole}>
+                  접속자수 {activeUsers} / {memberCount} 명{" "}
+                </span>
+              )}
+            </div>
           </div>
         </div>
-      </div>
-    </button>
+      </button>
+      {isOwner && (
+        <button
+          onClick={() => setIsRenameModalOpen(true)}
+          className={pencilButton}
+          aria-label="워크스페이스 이름 변경"
+        >
+          <PencilIcon />
+        </button>
+      )}
+      <RenameModal
+        isOpen={isRenameModalOpen}
+        onClose={() => setIsRenameModalOpen(false)}
+        onRename={handleRename}
+        currentName={name}
+      />
+    </div>
   );
 };

--- a/client/src/features/workSpace/components/OnboardingOverlay.style.ts
+++ b/client/src/features/workSpace/components/OnboardingOverlay.style.ts
@@ -37,7 +37,25 @@ export const tooltipDescription = css({
   marginBottom: "4",
   color: "gray.600",
 });
-
+export const closeButton = css({
+  position: "absolute",
+  top: "2",
+  right: "2",
+  borderRadius: "8px",
+  padding: "1",
+  color: "gray.500",
+  transition: "all",
+  _hover: {
+    color: "gray.700",
+    backgroundColor: "gray.100",
+  },
+  "& svg": {
+    // SVG 스타일 추가
+    width: "4",
+    height: "4",
+    color: "black",
+  },
+});
 export const IndicatorContainer = css({ display: "flex", gap: "2px" });
 export const stepIndicator = cva({
   base: {

--- a/client/src/features/workSpace/components/OnboardingOverlay.tsx
+++ b/client/src/features/workSpace/components/OnboardingOverlay.tsx
@@ -1,5 +1,6 @@
 import { motion } from "framer-motion";
 import { useState, useEffect } from "react";
+import CloseIcon from "@assets/icons/close.svg?react";
 import {
   overlayContainer,
   highlightBox,
@@ -8,6 +9,7 @@ import {
   tooltipDescription,
   stepIndicator,
   nextButton,
+  closeButton,
   IndicatorContainer,
 } from "./OnboardingOverlay.style";
 
@@ -85,6 +87,10 @@ export const OnboardingOverlay = ({ isShow }: OnboardingOverlayProps) => {
       setCurrentStep((prev) => prev - 1);
     }
   };
+  const handleOverlayClose = () => {
+    setIsVisible(false);
+    sessionStorage.setItem("hasCompletedOnboarding", "true");
+  };
   const getTargetPosition = (selector: string) => {
     const element = document.querySelector(selector);
     if (!element) {
@@ -161,6 +167,9 @@ export const OnboardingOverlay = ({ isShow }: OnboardingOverlayProps) => {
             top: tooltipPosition.top,
           }}
         >
+          <button onClick={handleOverlayClose} className={closeButton}>
+            <CloseIcon />
+          </button>
           <div className={IndicatorContainer}>
             {steps.map((_, index) => (
               <div key={index} className={stepIndicator({ active: index === currentStep })} />

--- a/client/src/stores/useSocketStore.ts
+++ b/client/src/stores/useSocketStore.ts
@@ -160,6 +160,9 @@ export const useSocketStore = create<SocketStore>((set, get) => ({
       const currentWorkspace = availableWorkspaces.find((ws) => ws.id === workspace!.id);
       if (currentWorkspace) {
         useWorkspaceStore.getState().setCurrentRole(currentWorkspace.role);
+        useWorkspaceStore.getState().setCurrentWorkspaceName(currentWorkspace.name);
+        useWorkspaceStore.getState().setCurrentActiveUsers(currentWorkspace.activeUsers);
+        useWorkspaceStore.getState().setCurrentMemberCount(currentWorkspace.memberCount);
       }
     });
 

--- a/client/src/stores/useSocketStore.ts
+++ b/client/src/stores/useSocketStore.ts
@@ -15,6 +15,7 @@ import {
 } from "@noctaCrdt/Interfaces";
 import { io, Socket } from "socket.io-client";
 import { create } from "zustand";
+import { useToastStore } from "./useToastStore";
 import { useWorkspaceStore } from "./useWorkspaceStore";
 
 class BatchProcessor {
@@ -140,6 +141,20 @@ export const useSocketStore = create<SocketStore>((set, get) => ({
       setWorkspace(workspace);
     });
 
+    socket.on(
+      "workspace/user/left",
+      (data: { workspaceId: string; userName: string; message: string }) => {
+        useToastStore.getState().addToast(data.message);
+      },
+    );
+
+    socket.on(
+      "workspace/user/join",
+      (data: { workspaceId: string; userName: string; message: string }) => {
+        useToastStore.getState().addToast(data.message);
+      },
+    );
+
     socket.on("workspace/connections", (connections: Record<string, number>) => {
       set({ workspaceConnections: connections });
     });
@@ -192,7 +207,7 @@ export const useSocketStore = create<SocketStore>((set, get) => ({
     // 기존 연결 정리
     if (socket) {
       if (workspace?.id) {
-        socket.emit("leave/workspace", { workspaceId: workspace.id });
+        socket.emit("leave/workspace", { workspaceId: workspace.id, userId });
       }
       socket.disconnect();
     }

--- a/client/src/stores/useWorkspaceStore.ts
+++ b/client/src/stores/useWorkspaceStore.ts
@@ -5,11 +5,22 @@ import { create } from "zustand";
 interface WorkspaceStore {
   // 현재 선택된 워크스페이스의 권한
   currentRole: string | null;
-  // 권한 설정 함수
+  currentWorkspaceName: string | null;
+  currentActiveUsers: number | null;
+  currentMemberCount: number | null;
   setCurrentRole: (role: string | null) => void;
+  setCurrentWorkspaceName: (name: string | null) => void;
+  setCurrentActiveUsers: (count: number | null) => void;
+  setCurrentMemberCount: (count: number | null) => void;
 }
 
 export const useWorkspaceStore = create<WorkspaceStore>((set) => ({
   currentRole: null,
   setCurrentRole: (role) => set({ currentRole: role }),
+  currentWorkspaceName: null,
+  setCurrentWorkspaceName: (name) => set({ currentWorkspaceName: name }),
+  currentActiveUsers: null,
+  setCurrentActiveUsers: (count) => set({ currentActiveUsers: count }),
+  currentMemberCount: null,
+  setCurrentMemberCount: (count) => set({ currentMemberCount: count }),
 }));

--- a/server/src/workspace/workspace.gateway.ts
+++ b/server/src/workspace/workspace.gateway.ts
@@ -142,6 +142,18 @@ export class WorkspaceGateway implements OnGatewayInit, OnGatewayConnection, OnG
       ).serialize();
       client.emit("workspace", currentWorkSpace);
 
+      if (user && NewWorkspaceId !== "guest") {
+        const server = this.workSpaceService.getServer();
+        server
+          .to(NewWorkspaceId)
+          .except(client.id)
+          .emit("workspace/user/join", {
+            workspaceId: NewWorkspaceId,
+            userName: user.name,
+            message: `${user.name}님이 워크스페이스에 참가하셨습니다.`,
+          });
+      }
+
       const assignedId = (this.clientIdCounter += 1);
       const clientInfo: ClientInfo = {
         clientId: assignedId,
@@ -168,7 +180,6 @@ export class WorkspaceGateway implements OnGatewayInit, OnGatewayConnection, OnG
         this.SocketStoreBroadcastWorkspaceConnections();
       }, 100);
 
-      client.broadcast.emit("userJoined", { clientId: assignedId });
       this.logger.log(`클라이언트 연결 성공 - User ID: ${userId}, Client ID: ${assignedId}`);
       this.logger.debug(`현재 연결된 클라이언트 수: ${this.clientMap.size}`);
     } catch (error) {
@@ -207,11 +218,19 @@ export class WorkspaceGateway implements OnGatewayInit, OnGatewayConnection, OnG
   Copy; // workspace.gateway.ts
   @SubscribeMessage("leave/workspace")
   async handleWorkspaceLeave(
-    @MessageBody() data: { workspaceId: string },
+    @MessageBody() data: { workspaceId: string; userId: string },
     @ConnectedSocket() client: Socket,
   ): Promise<void> {
     try {
       client.leave(data.workspaceId);
+      const user = await this.authService.findById(data.userId);
+      const server = this.workSpaceService.getServer();
+      console.log(data);
+      server.to(data.workspaceId).emit("workspace/user/left", {
+        workspaceId: data.workspaceId,
+        userName: user.name,
+        message: `${user.name}님이 워크스페이스에서 퇴장하셨습니다.`,
+      });
       this.SocketStoreBroadcastWorkspaceConnections();
     } catch (error) {
       this.logger.error(`워크스페이스 퇴장 중 오류 발생`, error.stack);


### PR DESCRIPTION
## 📝 변경 사항

### 워크스페이스 join, leave에 따라 워크스페이스 유저에게 토글창 표시

https://github.com/user-attachments/assets/6a3c82fa-c84a-425e-9246-b166a21fb7cd

### 워크스페이스 이름변경 추가
- 이름변경 모달
- 이름변경용 연필모양 버튼 추가

https://github.com/user-attachments/assets/efe3953f-348b-4a96-a320-46fe67f83ef9

### 온보딩 오버레이 바로끄는 close 아이콘 추가

![image](https://github.com/user-attachments/assets/4f239d73-b674-404e-813e-df45cf5d10b6)



## 🔍 변경 사항 설명

- api를 추가했습니다. `workspace/user/join` , `workspace/user/leave` 로 판단합니다.
- api를 추가했습니다. `workspace/rename`을 수신하고 `workspace/list`를 보내서 갱신합니다.

## 🙏 질문 사항

- [ ] 피드백 부탁드립니다!

## 📷 스크린샷 (선택)

- UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

## ✅ 작성자 체크리스트

- [x] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [x] 로컬에서 모든 기능이 정상 작동함
- [x] 린터 및 포맷터로 코드 정리됨
- [x] 의존성 업데이트 확인
- [ ] 문서 업데이트 또는 주석 추가 (필요 시)
