### PR TITLE
Hotfix/#299 붙여넣기 할 때 순서 리스트 유지되도록 수정

### DIFF
--- a/client/src/features/editor/hooks/useCopyAndPaste.ts
+++ b/client/src/features/editor/hooks/useCopyAndPaste.ts
@@ -32,7 +32,6 @@ export const useCopyAndPaste = ({
     sendCharDeleteOperation,
     sendBlockInsertOperation,
     sendBlockUpdateOperation,
-    sendBlockReorderOperation,
   } = useSocketStore();
 
   const handleCopy = useCallback(

--- a/client/src/features/editor/hooks/useCopyAndPaste.ts
+++ b/client/src/features/editor/hooks/useCopyAndPaste.ts
@@ -32,6 +32,7 @@ export const useCopyAndPaste = ({
     sendCharDeleteOperation,
     sendBlockInsertOperation,
     sendBlockUpdateOperation,
+    sendBlockReorderOperation,
   } = useSocketStore();
 
   const handleCopy = useCallback(
@@ -183,6 +184,7 @@ export const useCopyAndPaste = ({
             }
             currentBlockIndex += 1;
           });
+          editorCRDT.LinkedList.updateAllOrderedListIndices();
         } else {
           // 텍스트를 한 글자씩 순차적으로 삽입
           text.split("").forEach((char, index) => {


### PR DESCRIPTION
## 📝 변경 사항

- #299 

## 🔍 변경 사항 설명

현재 붙여넣기 지원되는 문법은 다음과 같습니다
- 모든 제목 태그
- 순서 리스트
- 순서 없는 리스트

## 🙏 질문 사항

## 📷 스크린샷 (선택)

## ✅ 작성자 체크리스트

- [x] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [x] 로컬에서 모든 기능이 정상 작동함
- [x] 린터 및 포맷터로 코드 정리됨
- [ ] 의존성 업데이트 확인
- [ ] 문서 업데이트 또는 주석 추가 (필요 시)
